### PR TITLE
add initial RDS compositions

### DIFF
--- a/compositions/aws-provider/rds/definition.yaml
+++ b/compositions/aws-provider/rds/definition.yaml
@@ -1,0 +1,108 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  name: xrelationaldatabases.awsblueprints.io
+spec:
+  group: awsblueprints.io
+  names:
+    kind: XRelationalDatabase
+    plural: xrelationaldatabases
+  claimNames:
+    kind: RelationalDatabase
+    plural: relationaldatabases
+  connectionSecretKeys:
+    - username
+    - password
+    - endpoint
+    - port
+  versions:
+    - name: v1alpha1
+      served: true
+      referenceable: true
+      schema:
+        openAPIV3Schema:
+          properties:
+            spec:
+              properties:
+                databaseName:
+                  type: string
+                dbSubnetGroupName:
+                  type: string
+                engineVersion: 
+                  type: string
+                storageGB:
+                  type: integer
+                subnetIds:
+                  type: array
+                  items:
+                    type: string
+                  minItems: 1
+                vpcId: 
+                  type: string
+                IngressRules:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      ipProtocol:
+                        type: string
+                      fromPort:
+                        type: integer
+                      toPort:
+                        type: integer
+                      ipRanges:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            cidrIp:
+                              type: string
+                resourceConfig:
+                  description: ResourceConfig defines general properties of this AWS
+                    resource.
+                  properties:
+                    deletionPolicy:
+                      description: Defaults to Delete
+                      enum:
+                      - Delete
+                      - Orphan
+                      type: string
+                    name:
+                      description: Set the name of this resource in AWS to the value provided by this field.
+                      type: string
+                    providerConfigName:
+                      type: string
+                    region:
+                      type: string
+                    tags:
+                      items:
+                        properties:
+                          key:
+                            type: string
+                          value:
+                            type: string
+                        required:
+                        - key
+                        - value
+                        type: object
+                      type: array
+                  required:
+                  - providerConfigName
+                  - region
+                  - tags
+                  type: object
+              required:
+              - resourceConfig
+              type: object
+            status:
+              properties:
+                securityGroupId:
+                  type: string
+                clusterId:
+                  type: string
+              type: object
+          type: object
+

--- a/compositions/aws-provider/rds/postgres-aurora.yaml
+++ b/compositions/aws-provider/rds/postgres-aurora.yaml
@@ -1,0 +1,201 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: rds-aurora-postgresql.awsblueprints.io
+  labels:
+    awsblueprints.io/provider: aws
+    awsblueprints.io/environment: staging
+    awsblueprints.io/createDBSubnetGroup: "true"
+spec:
+  writeConnectionSecretsToNamespace: crossplane-system
+  compositeTypeRef:
+    apiVersion: awsblueprints.io/v1alpha1
+    kind: XRelationalDatabase
+  patchSets:
+    - name: common-fields
+      patches:
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.resourceConfig.providerConfigName
+          toFieldPath: spec.providerConfigRef.name
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.resourceConfig.deletionPolicy
+          toFieldPath: spec.deletionPolicy
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.resourceConfig.region
+          toFieldPath: spec.forProvider.region
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.resourceConfig.tags
+          toFieldPath: spec.forProvider.tags
+          policy:
+            mergeOptions:
+              appendSlice: true
+        - fromFieldPath: spec.writeConnectionSecretToRef.namespace
+          toFieldPath: spec.writeConnectionSecretToRef.namespace
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.resourceConfig.name
+          toFieldPath: metadata.annotations[crossplane.io/external-name]
+  resources:
+    - base:
+        apiVersion: database.aws.crossplane.io/v1beta1
+        kind: DBSubnetGroup
+        spec:
+          forProvider:
+            description: "rds-postgres"
+      patches:
+        - type: PatchSet
+          patchSetName: common-fields
+        - fromFieldPath: "spec.subnetIds"
+          toFieldPath: spec.forProvider.subnetIds
+        - fromFieldPath: "metadata.uid"
+          toFieldPath: "spec.writeConnectionSecretToRef.name"
+          transforms:
+            - type: string
+              string:
+                fmt: "%s-dbsubnet"
+    - base:
+        apiVersion: ec2.aws.crossplane.io/v1beta1
+        kind: SecurityGroup
+        spec:
+          forProvider:
+            description: "rds-postgres-sg"
+            ingress:
+              - ipProtocol: tcp
+                fromPort: 5432
+                toPort: 5432
+                ipRanges:
+                  - cidrIp: "10.0.0.0/8"
+      patches:
+        - type: PatchSet
+          patchSetName: common-fields
+        - type: ToCompositeFieldPath
+          fromFieldPath: status.atProvider.securityGroupID
+          toFieldPath: status.securityGroupId
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.IngressRules
+          toFieldPath: spec.forProvider.ingress
+          policy:
+            mergeOptions:
+              appendSlice: true
+        - fromFieldPath: "metadata.uid"
+          toFieldPath: "spec.forProvider.groupName"
+          transforms:
+            - type: string
+              string:
+                fmt: "rds-postgres-sg-%s"
+        - fromFieldPath: "spec.vpcId"
+          toFieldPath: "spec.forProvider.vpcId"
+        - fromFieldPath: "metadata.uid"
+          toFieldPath: "spec.writeConnectionSecretToRef.name"
+          transforms:
+            - type: string
+              string:
+                fmt: "%s-db-sg"
+    - base:
+        apiVersion: rds.aws.crossplane.io/v1alpha1
+        kind: DBCluster
+        spec:
+          forProvider:
+            backupRetentionPeriod: 7
+            copyTagsToSnapshot: true
+            dbSubnetGroupNameSelector:
+              matchControllerRef: true
+            enableHTTPEndpoint: false
+            engine: aurora-postgresql
+            engineVersion: "13.6"
+            finalDBSnapshotIdentifier: "to-be-patched"
+            masterUserPasswordSecretRef:
+              key: password
+              name: postgres-root-user-password
+              namespace: crossplane-system
+            masterUsername: root
+            preferredBackupWindow: 02:00-03:00
+            preferredMaintenanceWindow: sun:04:00-sun:05:00
+            skipFinalSnapshot: false
+            storageEncrypted: true
+            vpcSecurityGroupIDs: [] 
+            # This is a workaround for SGs not getting updated properly. https://github.com/crossplane/provider-aws/issues/1153
+            # https://github.com/crossplane/crossplane-runtime/issues/250
+            vpcSecurityGroupIDSelector:
+              matchControllerRef: true
+      patches:
+        - type: PatchSet
+          patchSetName: common-fields
+        - fromFieldPath: spec.writeConnectionSecretToRef.namespace
+          toFieldPath: spec.writeConnectionSecretToRef.namespace
+        - fromFieldPath: metadata.labels[crossplane.io/claim-namespace]
+          toFieldPath: spec.forProvider.masterUserPasswordSecretRef.namespace
+        - fromFieldPath: "metadata.uid"
+          toFieldPath: "spec.writeConnectionSecretToRef.name"
+          transforms:
+            - type: string
+              string:
+                fmt: "%s-postgresql"
+        - fromFieldPath: "metadata.name"
+          toFieldPath: "spec.forProvider.finalDBSnapshotIdentifier"
+          transforms:
+            - type: string
+              string:
+                fmt: "%s-final-snapshot"
+        - fromFieldPath: "spec.engineVersion"
+          toFieldPath: "spec.forProvider.engineVersion"
+        - fromFieldPath: "spec.databaseName"
+          toFieldPath: "spec.forProvider.databaseName"
+        - type: ToCompositeFieldPath
+          fromFieldPath: status.atProvider.dbClusterIdentifier
+          toFieldPath: status.clusterId
+      connectionDetails:
+        - fromConnectionSecretKey: username
+        - fromConnectionSecretKey: password
+        - fromConnectionSecretKey: endpoint
+        - fromConnectionSecretKey: port
+    - base:
+        apiVersion: rds.aws.crossplane.io/v1alpha1
+        kind: DBInstance
+        spec:
+          forProvider:
+            autogeneratePassword: false
+            dbClusterIdentifier: "to-be-patched"
+            dbSubnetGroupNameSelector:
+              matchControllerRef: true
+            dbInstanceClass: db.r5.xlarge
+            engine: aurora-postgresql
+      patches:
+        - type: PatchSet
+          patchSetName: common-fields
+        - fromFieldPath: spec.writeConnectionSecretToRef.namespace
+          toFieldPath: spec.writeConnectionSecretToRef.namespace
+        - fromFieldPath: "metadata.uid"
+          toFieldPath: "spec.writeConnectionSecretToRef.name"
+          transforms:
+            - type: string
+              string:
+                fmt: "%s-cluster-postgres-1"
+        - fromFieldPath: "status.clusterId"
+          toFieldPath: "spec.forProvider.dbClusterIdentifier"
+    - base:
+        apiVersion: rds.aws.crossplane.io/v1alpha1
+        kind: DBInstance
+        spec:
+          forProvider:
+            autogeneratePassword: false
+            dbClusterIdentifier: "to-be-patched"
+            dbSubnetGroupNameSelector:
+              matchControllerRef: true
+            dbInstanceClass: db.r5.xlarge
+            engine: aurora-postgresql
+      patches:
+        - type: PatchSet
+          patchSetName: common-fields
+        - fromFieldPath: spec.writeConnectionSecretToRef.namespace
+          toFieldPath: spec.writeConnectionSecretToRef.namespace
+        - fromFieldPath: "metadata.uid"
+          toFieldPath: "spec.writeConnectionSecretToRef.name"
+          transforms:
+            - type: string
+              string:
+                fmt: "%s-cluster-postgres-2"
+        - fromFieldPath: "status.clusterId"
+          toFieldPath: "spec.forProvider.dbClusterIdentifier"

--- a/compositions/aws-provider/rds/rds-postgres.yaml
+++ b/compositions/aws-provider/rds/rds-postgres.yaml
@@ -1,0 +1,154 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: rds-postgresql.awsblueprints.io
+  labels:
+    awsblueprints.io/provider: aws
+    awsblueprints.io/environment: dev
+    awsblueprints.io/createDBSubnetGroup: "true"
+spec:
+  writeConnectionSecretsToNamespace: crossplane-system
+  compositeTypeRef:
+    apiVersion: awsblueprints.io/v1alpha1
+    kind: XRelationalDatabase
+  patchSets:
+    - name: common-fields
+      patches:
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.resourceConfig.providerConfigName
+          toFieldPath: spec.providerConfigRef.name
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.resourceConfig.deletionPolicy
+          toFieldPath: spec.deletionPolicy
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.resourceConfig.region
+          toFieldPath: spec.forProvider.region
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.resourceConfig.tags
+          toFieldPath: spec.forProvider.tags
+          policy:
+            mergeOptions:
+              appendSlice: true
+        - fromFieldPath: spec.writeConnectionSecretToRef.namespace
+          toFieldPath: spec.writeConnectionSecretToRef.namespace
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.resourceConfig.name
+          toFieldPath: metadata.annotations[crossplane.io/external-name]
+  resources:
+    - base:
+        apiVersion: database.aws.crossplane.io/v1beta1
+        kind: DBSubnetGroup
+        spec:
+          forProvider:
+            description: "rds-postgres"
+      patches:
+        - type: PatchSet
+          patchSetName: common-fields
+        - fromFieldPath: "spec.subnetIds"
+          toFieldPath: spec.forProvider.subnetIds
+        - fromFieldPath: "metadata.uid"
+          toFieldPath: "spec.writeConnectionSecretToRef.name"
+          transforms:
+            - type: string
+              string:
+                fmt: "%s-dbsubnet"
+    - base:
+        apiVersion: ec2.aws.crossplane.io/v1beta1
+        kind: SecurityGroup
+        spec:
+          forProvider:
+            description: "rds-postgres-sg"
+            ingress:
+              - ipProtocol: tcp
+                fromPort: 5432
+                toPort: 5432
+                ipRanges:
+                  - cidrIp: "10.0.0.0/8"
+            tags:
+              - key: rds-db-type
+                value: postgres
+      patches:
+        - type: PatchSet
+          patchSetName: common-fields
+        - type: ToCompositeFieldPath
+          fromFieldPath: status.atProvider.securityGroupID
+          toFieldPath: status.securityGroupId
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.IngressRules
+          toFieldPath: spec.forProvider.ingress
+          policy:
+            mergeOptions:
+              appendSlice: true
+        - fromFieldPath: "metadata.uid"
+          toFieldPath: "spec.forProvider.groupName"
+          transforms:
+            - type: string
+              string:
+                fmt: "rds-postgres-sg-%s"
+        - fromFieldPath: "spec.vpcId"
+          toFieldPath: "spec.forProvider.vpcId"
+        - fromFieldPath: "metadata.uid"
+          toFieldPath: "spec.writeConnectionSecretToRef.name"
+          transforms:
+            - type: string
+              string:
+                fmt: "%s-db-sg"
+    - base:
+        apiVersion: rds.aws.crossplane.io/v1alpha1
+        kind: DBInstance
+        spec:
+          forProvider:
+            applyImmediately: true
+            autogeneratePassword: true
+            backupRetentionPeriod: 3
+            dbSubnetGroupNameSelector:
+              matchControllerRef: true
+            dbInstanceClass: db.t4g.small
+            dbParameterGroupName: default.postgres14
+            masterUsername: root
+            masterUserPasswordSecretRef:
+              key: password
+              name: to-be-patched
+              namespace: crossplane-system
+            engine: postgres
+            engineVersion: "14.2"
+            skipFinalSnapshot: true
+            storageEncrypted: true
+            storageType: gp2
+            publiclyAccessible: false
+            vpcSecurityGroupIDs: []
+            vpcSecurityGroupIDSelector:
+              matchControllerRef: true
+      patches:
+        - type: PatchSet
+          patchSetName: common-fields
+        - fromFieldPath: spec.writeConnectionSecretToRef.namespace
+          toFieldPath: spec.writeConnectionSecretToRef.namespace
+        - fromFieldPath: "metadata.uid"
+          toFieldPath: "spec.writeConnectionSecretToRef.name"
+          transforms:
+            - type: string
+              string:
+                fmt: "%s-postgresql"
+        - fromFieldPath: "metadata.uid"
+          toFieldPath: "spec.forProvider.masterUserPasswordSecretRef.name"
+          transforms:
+            - type: string
+              string:
+                fmt: "%s-user"
+        - fromFieldPath: "spec.storageGB"
+          toFieldPath: "spec.forProvider.allocatedStorage"
+        - fromFieldPath: "spec.engineVersion"
+          toFieldPath: "spec.forProvider.engineVersion"
+        - fromFieldPath: "status.securityGroupId"
+          toFieldPath: "spec.forProvider.vpcSecurityGroupIDs[0]"
+        - fromFieldPath: "spec.databaseName"
+          toFieldPath: "spec.forProvider.dbName"
+      connectionDetails:
+        - fromConnectionSecretKey: username
+        - fromConnectionSecretKey: password
+        - fromConnectionSecretKey: endpoint
+        - fromConnectionSecretKey: port

--- a/examples/aws-provider/composite-resources/rds/aurora-postgres.yaml
+++ b/examples/aws-provider/composite-resources/rds/aurora-postgres.yaml
@@ -1,0 +1,46 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# Update spec.subnetIds and spec.vpcId fields before use.
+# The Kubernetes secret below is used to create the master user password for RDS. Unfortunately, auto generated passwords are not supported by RDS cluster yet.
+# Run `kubectl apply -f aurora-postgres.yaml` to test this example once you bootstrap the EKS cluster with Crossplane and AWS Provider
+
+
+# This example resource creates the following resources
+#     1. Two RDS Postgres Instance 
+#     2. RDS Aurora cluster
+#     3. RDS subnet group
+#     4. EC2 Security group
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgres-root-user-password
+  namespace: default
+data:
+  password: bXlzZWNyZXRQYXNzd29yZDEh # mysecretPassword1!
+---
+apiVersion: awsblueprints.io/v1alpha1
+kind: RelationalDatabase
+metadata:
+  name: test-aurora-postgresql-db
+  namespace: default
+spec:
+  compositionSelector:
+    matchLabels:
+      awsblueprints.io/provider: aws
+      awsblueprints.io/environment: staging
+      awsblueprints.io/createDBSubnetGroup: "true"
+  writeConnectionSecretToRef:
+    name: test-aurora-postgresql-db # secret contains endpoint, username, and password.
+  resourceConfig:
+    providerConfigName: aws-provider-config
+    region: us-west-2
+    tags:
+      - key: testKey
+        value: testValue
+  databaseName: "test"
+  subnetIds:
+    - subnet-123 # change these values before use
+    - subnet-456
+  vpcId: vpc-789

--- a/examples/aws-provider/composite-resources/rds/postgres.yaml
+++ b/examples/aws-provider/composite-resources/rds/postgres.yaml
@@ -1,0 +1,35 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# Update spec.subnetIds and spec.vpcId fields before use.
+# Run `kubectl apply -f postgres.yaml` to test this example once you bootstrap the EKS cluster with Crossplane and AWS Provider
+
+# This example resource creates the following resources
+#     1. RDS Postgres Instance with auto generated password
+#     2. RDS subnet group
+#     3. EC2 Security group
+
+apiVersion: awsblueprints.io/v1alpha1
+kind: RelationalDatabase
+metadata:
+  name: test-postgresql-db
+  namespace: default
+spec:
+  compositionSelector:
+    matchLabels:
+      awsblueprints.io/provider: aws
+      awsblueprints.io/environment: dev
+      awsblueprints.io/createDBSubnetGroup: "true"
+  writeConnectionSecretToRef:
+    name: test-postgresql-db # secret contains endpoint, username, and password.
+  resourceConfig:
+    providerConfigName: aws-provider-config
+    region: us-west-2
+    tags:
+      - key: env
+        value: test
+  storageGB: 100
+  subnetIds:
+    - subnet-123 # change these values before use
+    - subnet-456
+  vpcId: vpc-789


### PR DESCRIPTION
### What does this PR do?

adds initial RDS compositions and examples


### Motivation

We need RDS compositions


### More

- [x] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)

- [x] Yes, I have added a new example under [examples](https://github.com/aws-samples/crossplane-aws-blueprints/tree/main/examples) to support my PR

- [x] Yes, I have updated the [docs](https://github.com/aws-samples/crossplane-aws-blueprints/tree/main/doc) for this feature

- [x] Yes, I have linked to an issue or feature request (applicable to PRs that solves a bug or a feature request)

**Note**:
 - Not all the PRs require examples and docs
 - We prefer small, well tested pull requests. Please ensure your pull requests are self-contained, and commits are squashed

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

RDS compositions use a work around to populate Security Groups correctly. This needs to be fixed in Crossplane core. 

https://github.com/crossplane/provider-aws/issues/1153

