### PR TITLE
fix local variable name

### DIFF
--- a/bootstrap/terraform/main.tf
+++ b/bootstrap/terraform/main.tf
@@ -86,7 +86,7 @@ locals {
   tenant             = var.tenant         # AWS account name or unique id for tenant
   environment        = var.environment    # Environment area eg., preprod or prod
   zone               = var.zone           # Environment with in one sub_tenant or business unit
-  kubernetes_version = var.kubernetes_version
+  cluster_version = var.cluster_version
   azs  = data.aws_availability_zones.available.names
 
   vpc_cidr     = var.vpc_cidr


### PR DESCRIPTION
### What does this PR do?

Fix terraform error:
```
➜  bootstrap/terraform git:(main) ✗ terraform plan
│ Error: Reference to undeclared input variable
│
│   on main.tf line 89, in locals:
│   89:   kubernetes_version = var.kubernetes_version
│
│ An input variable with the name "kubernetes_version" has not been declared. This variable can be declared with a variable "kubernetes_version" {} block.
╵
╷
│ Error: Reference to undeclared local value
│
│   on main.tf line 148, in module "aws-eks-accelerator-for-terraform":
│  148:   cluster_version = local.cluster_version
│
│ A local value with the name "cluster_version" has not been declared.
╵
```


### Motivation

Terraform bootstrap should be usable

