### PR TITLE
fix(vpc-parameters):  fix for provider-jet-aws parameters ec2/vpc

### DIFF
--- a/compositions/terrajet-aws-provider/vpc/definition.yaml
+++ b/compositions/terrajet-aws-provider/vpc/definition.yaml
@@ -51,7 +51,7 @@ spec:
                       description: enable DNS Support
                       type: boolean
                       default: true
-                    enableDnsHostNames:
+                    enableDnsHostnames:
                       description: enable DNS Hostnames
                       type: boolean
                       default: true

--- a/compositions/terrajet-aws-provider/vpc/vpc-composition.yaml
+++ b/compositions/terrajet-aws-provider/vpc/vpc-composition.yaml
@@ -42,7 +42,7 @@ spec:
         spec:
           forProvider:
             enableDnsSupport: ""
-            enableDnsHostNames: ""
+            enableDnsHostnames: ""
             cidrBlock: ""
             tags:
               Name: ""
@@ -60,5 +60,5 @@ spec:
           fromFieldPath: spec.parameters.enableDnsSupport
           toFieldPath: spec.forProvider.enableDnsSupport
         - type: FromCompositeFieldPath
-          fromFieldPath: spec.parameters.enableDnsHostNames
-          toFieldPath: spec.forProvider.enableDnsHostNames
+          fromFieldPath: spec.parameters.enableDnsHostnames
+          toFieldPath: spec.forProvider.enableDnsHostnames

--- a/examples/terrajet-aws-provider/managed-resources/vpc.yaml
+++ b/examples/terrajet-aws-provider/managed-resources/vpc.yaml
@@ -10,9 +10,9 @@ metadata:
 spec:
   forProvider:
     region: eu-west-1
-    enableDnsHostNames: true
+    enableDnsHostnames: true
     enableDnsSupport: true
-    enableClasiclink: true
+    enableClassiclink: true
     cidrBlock: 10.30.0.0/16
     enableClassiclinkDnsSupport: true
     tags:


### PR DESCRIPTION
Signed-off-by: haarchri <chhaar30@googlemail.com>


### What does this PR do?
followup for https://github.com/crossplane-contrib/provider-jet-aws/issues/162 
corrected the parameters for provider-jet-aws ec2/vpc resource 
- fixed example
- fixed definition
- fixed composition resource

<!-- A brief description of the change being made with this pull request. -->


### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [x] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)

- [x] Yes, I have added a new example under [examples](https://github.com/aws-samples/crossplane-aws-blueprints/tree/main/examples) to support my PR

- [ ] Yes, I have updated the [docs](https://github.com/aws-samples/crossplane-aws-blueprints/tree/main/doc) for this feature

- [x] Yes, I have linked to an issue or feature request (applicable to PRs that solves a bug or a feature request)

**Note**:
 - Not all the PRs require examples and docs
 - We prefer small, well tested pull requests. Please ensure your pull requests are self-contained, and commits are squashed

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
