### PR TITLE
Use subnetIdSelector.matchLabels for subnet selection in EKS composition

### DIFF
--- a/compositions/aws-provider/eks/definition.yaml
+++ b/compositions/aws-provider/eks/definition.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   connectionSecretKeys:
     - kubeconfig
+    - cluster-ca
+    - apiserver-endpoint
   group: cluster.awsblueprints.io
   names:
     kind: XAmazonEks        # cluster scope type

--- a/compositions/aws-provider/eks/definition.yaml
+++ b/compositions/aws-provider/eks/definition.yaml
@@ -54,12 +54,18 @@ spec:
                       description: endpointPublicAccess
                       type: boolean
                       default: true
+                    subnetIds:
+                      description: EKS Cluster Subnet Id references
+                      items:
+                        type: string
+                      type: array
+                      default: []
                     networkId:
                       description: Name of network to use for subnet lookup (subnet label 'network.awsblueprints.io/network-id').
                       type: string
+                      default: ""
                   required:
                     - version
-                    - networkId
                 managedNodeGroups:
                   description: Managed Node Groups properties
                   type: object

--- a/compositions/aws-provider/eks/definition.yaml
+++ b/compositions/aws-provider/eks/definition.yaml
@@ -54,14 +54,12 @@ spec:
                       description: endpointPublicAccess
                       type: boolean
                       default: true
-                    subnetIds:
-                      description: EKS Cluster Subnet Id references
-                      items:
-                        type: string
-                      type: array
+                    networkId:
+                      description: Name of network to use for subnet lookup (subnet label 'network.awsblueprints.io/network-id').
+                      type: string
                   required:
                     - version
-                    - subnetIds
+                    - networkId
                 managedNodeGroups:
                   description: Managed Node Groups properties
                   type: object

--- a/compositions/aws-provider/eks/definition.yaml
+++ b/compositions/aws-provider/eks/definition.yaml
@@ -57,13 +57,13 @@ spec:
                       type: boolean
                       default: true
                     subnetIds:
-                      description: EKS Cluster Subnet Id references
+                      description: EKS Cluster Subnet Id references. Unused in compositions that use label-based subnet lookup through the 'networkId' parameter
                       items:
                         type: string
                       type: array
                       default: []
                     networkId:
-                      description: Name of network to use for subnet lookup (subnet label 'network.awsblueprints.io/network-id').
+                      description: Name of network to use for label-based subnet lookup (subnet label 'network.awsblueprints.io/network-id'). Unused in compositions that use explicit subnet Id through the 'subnetIds' parameter
                       type: string
                       default: ""
                   required:

--- a/compositions/aws-provider/eks/eks-managed-node-group-subnet-labels.yaml
+++ b/compositions/aws-provider/eks/eks-managed-node-group-subnet-labels.yaml
@@ -1,0 +1,300 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+---
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: xamazonekss-subnet-labels.cluster.awsblueprints.io
+  labels:
+    awsblueprints.io/provider: aws
+    awsblueprints.io/environment: dev
+    awsblueprints.io/subnet-selection: label
+    crossplane.io/xrd: xamazonekss.cluster.awsblueprints.io
+    service: eks
+spec:
+  writeConnectionSecretsToNamespace: crossplane-system
+  compositeTypeRef:
+    apiVersion: cluster.awsblueprints.io/v1alpha1
+    kind: XAmazonEks
+
+  patchSets:
+    - name: common-parameters
+      patches:
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.resourceConfig.providerConfigName
+          toFieldPath: spec.providerConfigRef.name
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.resourceConfig.deletionPolicy
+          toFieldPath: spec.deletionPolicy
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.resourceConfig.region
+          toFieldPath: spec.forProvider.region
+#        - type: FromCompositeFieldPath
+#          fromFieldPath: spec.resourceConfig.name
+#          toFieldPath: metadata.annotations[crossplane.io/external-name]
+
+  resources:
+    - name: eks-cluster
+      base:
+        apiVersion: eks.aws.crossplane.io/v1beta1
+        kind: Cluster
+        metadata:
+          labels:
+            role: controlplane
+        spec:
+          forProvider:
+            version:
+            roleArnSelector:
+              matchControllerRef: true
+              matchLabels:
+                role: controlplane
+            resourcesVpcConfig:
+              endpointPrivateAccess:
+              endpointPublicAccess:
+              subnetIdSelector:
+                matchLabels:
+                  network.awsblueprints.io/network-id:
+          writeConnectionSecretToRef:
+            namespace: crossplane-system
+      patches:
+        - type: PatchSet
+          patchSetName: common-parameters
+        - fromFieldPath: metadata.annotations[crossplane.io/external-name]
+          toFieldPath: metadata.annotations[crossplane.io/external-name]
+        - fromFieldPath: spec.parameters.version
+          toFieldPath: spec.forProvider.version
+        - fromFieldPath: spec.parameters.networkId
+          toFieldPath: spec.forProvider.resourcesVpcConfig.subnetIdSelector.matchLabels[network.awsblueprints.io/network-id]
+        - fromFieldPath: spec.parameters.endpointPrivateAccess
+          toFieldPath: spec.forProvider.resourcesVpcConfig.endpointPrivateAccess
+        - fromFieldPath: spec.parameters.endpointPublicAccess
+          toFieldPath: spec.forProvider.resourcesVpcConfig.endpointPublicAccess
+        - fromFieldPath: metadata.uid
+          toFieldPath: spec.writeConnectionSecretToRef.name
+          transforms:
+            - type: string
+              string:
+                fmt: "%s-eks-cluster-conn"
+        - fromFieldPath: spec.writeConnectionSecretToRef.namespace
+          toFieldPath: spec.writeConnectionSecretToRef.namespace
+#        - type: ToCompositeFieldPath
+#          fromFieldPath: status.atProvider.identity.oidc.issuer
+#          toFieldPath: status.eks.oidc
+#          policy:
+#            fromFieldPath: Optional
+        - type: ToCompositeFieldPath
+          fromFieldPath: status.atProvider.resourcesVpcConfig.vpcId
+          toFieldPath: status.vpcId
+      connectionDetails:
+        - name: cluster-ca
+          fromConnectionSecretKey: clusterCA
+        - name: apiserver-endpoint
+          fromConnectionSecretKey: endpoint
+        - name: kubeconfig
+          fromConnectionSecretKey: kubeconfig
+    - name: eks-cluster-role
+      base:
+        apiVersion: iam.aws.crossplane.io/v1beta1
+        kind: Role
+        metadata:
+          labels:
+            role: controlplane
+        spec:
+          forProvider:
+            assumeRolePolicyDocument: |
+              {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Principal": {
+                            "Service": [
+                                "eks.amazonaws.com"
+                            ]
+                        },
+                        "Action": [
+                            "sts:AssumeRole"
+                        ]
+                    }
+                ]
+              }
+      patches:
+        - type: PatchSet
+          patchSetName: common-parameters
+    - name: eks-cluster-policy
+      base:
+        apiVersion: iam.aws.crossplane.io/v1beta1
+        kind: RolePolicyAttachment
+        spec:
+          forProvider:
+            policyArn: arn:aws:iam::aws:policy/AmazonEKSClusterPolicy
+            roleNameSelector:
+              matchControllerRef: true
+              matchLabels:
+                role: controlplane
+      patches:
+        - type: PatchSet
+          patchSetName: common-parameters
+    - name: eks-service-policy
+      base:
+        apiVersion: iam.aws.crossplane.io/v1beta1
+        kind: RolePolicyAttachment
+        spec:
+          forProvider:
+            policyArn: arn:aws:iam::aws:policy/AmazonEKSServicePolicy
+            roleNameSelector:
+              matchControllerRef: true
+              matchLabels:
+                role: controlplane
+      patches:
+        - type: PatchSet
+          patchSetName: common-parameters
+    - name: eks-vpcresource-controller-policy
+      base:
+        apiVersion: iam.aws.crossplane.io/v1beta1
+        kind: RolePolicyAttachment
+        spec:
+          forProvider:
+            policyArn: arn:aws:iam::aws:policy/AmazonEKSVPCResourceController
+            roleNameSelector:
+              matchControllerRef: true
+              matchLabels:
+                role: controlplane
+      patches:
+        - type: PatchSet
+          patchSetName: common-parameters
+
+# EKS Managed Node groups
+    - name: eks-managed-nodegroups
+      base:
+        apiVersion: eks.aws.crossplane.io/v1alpha1
+        kind: NodeGroup
+        spec:
+          forProvider:
+            amiType:
+            clusterNameSelector:
+              matchControllerRef: true
+              matchLabels:
+                role: controlplane
+            nodeRoleSelector:
+              matchControllerRef: true
+              matchLabels:
+                role: managed-nodegroup
+            subnetSelector:
+              matchLabels:
+                network.awsblueprints.io/network-id:
+                visibility: private
+            scalingConfig:
+              minSize:
+              desiredSize:
+              maxSize:
+            capacityType:
+            instanceTypes:
+      patches:
+        - type: PatchSet
+          patchSetName: common-parameters
+        - fromFieldPath: metadata.annotations[crossplane.io/external-name]
+          toFieldPath: metadata.annotations[crossplane.io/external-name]
+        - fromFieldPath: spec.managedNodeGroups.minSize
+          toFieldPath: spec.forProvider.scalingConfig.minSize
+        - fromFieldPath: spec.managedNodeGroups.maxSize
+          toFieldPath: spec.forProvider.scalingConfig.maxSize
+        - fromFieldPath: spec.managedNodeGroups.desiredSize
+          toFieldPath: spec.forProvider.scalingConfig.desiredSize
+        - fromFieldPath: spec.managedNodeGroups.desiredSize
+          toFieldPath: spec.forProvider.scalingConfig.desiredSize
+        - fromFieldPath: spec.managedNodeGroups.capacityType
+          toFieldPath: spec.forProvider.capacityType
+        - fromFieldPath: spec.managedNodeGroups.instanceTypes
+          toFieldPath: spec.forProvider.instanceTypes
+        - fromFieldPath: spec.managedNodeGroups.amiType
+          toFieldPath: spec.forProvider.amiType
+        - fromFieldPath: spec.parameters.networkId
+          toFieldPath: spec.forProvider.subnetSelector.matchLabels[network.awsblueprints.io/network-id]
+
+    - name: eks-managed-nodegroup-iam-role
+      base:
+        apiVersion: iam.aws.crossplane.io/v1beta1
+        kind: Role
+        metadata:
+          labels:
+            role: managed-nodegroup
+        spec:
+          forProvider:
+            assumeRolePolicyDocument: |
+              {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Principal": {
+                            "Service": [
+                                "ec2.amazonaws.com"
+                            ]
+                        },
+                        "Action": [
+                            "sts:AssumeRole"
+                        ]
+                    }
+                ]
+              }
+      patches:
+        - type: PatchSet
+          patchSetName: common-parameters
+    - name: eks-managed-nodegroup-worker-node-policy
+      base:
+        apiVersion: iam.aws.crossplane.io/v1beta1
+        kind: RolePolicyAttachment
+        spec:
+          forProvider:
+            policyArn: arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy
+            roleNameSelector:
+              matchControllerRef: true
+              matchLabels:
+                role:  managed-nodegroup
+      patches:
+        - type: PatchSet
+          patchSetName: common-parameters
+    - name: eks-managed-nodegroup-container-registry-policy
+      base:
+        apiVersion: iam.aws.crossplane.io/v1beta1
+        kind: RolePolicyAttachment
+        spec:
+          forProvider:
+            policyArn: arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
+            roleNameSelector:
+              matchControllerRef: true
+              matchLabels:
+                role: managed-nodegroup
+      patches:
+        - type: PatchSet
+          patchSetName: common-parameters
+    - name: eks-managed-nodegroup-ssm-policy
+      base:
+        apiVersion: iam.aws.crossplane.io/v1beta1
+        kind: RolePolicyAttachment
+        spec:
+          forProvider:
+            policyArn: arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+            roleNameSelector:
+              matchControllerRef: true
+              matchLabels:
+                role: managed-nodegroup
+      patches:
+        - type: PatchSet
+          patchSetName: common-parameters
+    - name: eks-managed-nodegroup-cni-policy
+      base:
+        apiVersion: iam.aws.crossplane.io/v1beta1
+        kind: RolePolicyAttachment
+        spec:
+          forProvider:
+            policyArn: arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy
+            roleNameSelector:
+              matchControllerRef: true
+              matchLabels:
+                role: managed-nodegroup
+      patches:
+        - type: PatchSet
+          patchSetName: common-parameters

--- a/compositions/aws-provider/eks/eks-managed-node-group-subnet-labels.yaml
+++ b/compositions/aws-provider/eks/eks-managed-node-group-subnet-labels.yaml
@@ -83,9 +83,6 @@ spec:
 #          toFieldPath: status.eks.oidc
 #          policy:
 #            fromFieldPath: Optional
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.atProvider.resourcesVpcConfig.vpcId
-          toFieldPath: status.vpcId
       connectionDetails:
         - name: cluster-ca
           fromConnectionSecretKey: clusterCA

--- a/compositions/aws-provider/eks/eks-managed-node-group.yaml
+++ b/compositions/aws-provider/eks/eks-managed-node-group.yaml
@@ -43,7 +43,7 @@ spec:
             role: controlplane
         spec:
           forProvider:
-            verison:
+            version:
             roleArnSelector:
               matchControllerRef: true
               matchLabels:
@@ -51,7 +51,9 @@ spec:
             resourcesVpcConfig:
               endpointPrivateAccess:
               endpointPublicAccess:
-              subnetIds:
+              subnetIdSelector:
+                matchLabels:
+                  network.awsblueprints.io/network-id:
           writeConnectionSecretToRef:
             namespace: crossplane-system
       patches:
@@ -61,8 +63,8 @@ spec:
           toFieldPath: metadata.annotations[crossplane.io/external-name]
         - fromFieldPath: spec.parameters.version
           toFieldPath: spec.forProvider.version
-        - fromFieldPath: spec.parameters.subnetIds
-          toFieldPath: spec.forProvider.resourcesVpcConfig.subnetIds
+        - fromFieldPath: spec.parameters.networkId
+          toFieldPath: spec.forProvider.resourcesVpcConfig.subnetIdSelector.matchLabels[network.awsblueprints.io/network-id]
         - fromFieldPath: spec.parameters.endpointPrivateAccess
           toFieldPath: spec.forProvider.resourcesVpcConfig.endpointPrivateAccess
         - fromFieldPath: spec.parameters.endpointPublicAccess
@@ -80,6 +82,9 @@ spec:
 #          toFieldPath: status.eks.oidc
 #          policy:
 #            fromFieldPath: Optional
+        - type: ToCompositeFieldPath
+          fromFieldPath: status.atProvider.resourcesVpcConfig.vpcId
+          toFieldPath: status.vpcId
       connectionDetails:
         - name: cluster-ca
           fromConnectionSecretKey: clusterCA
@@ -175,10 +180,10 @@ spec:
               matchControllerRef: true
               matchLabels:
                 role: managed-nodegroup
-            subnets:
-#            subnetSelector:
-#              matchLabels:
-#                access: private
+            subnetSelector:
+              matchLabels:
+                network.awsblueprints.io/network-id:
+                visibility: private
             scalingConfig:
               minSize:
               desiredSize:
@@ -204,8 +209,8 @@ spec:
           toFieldPath: spec.forProvider.instanceTypes
         - fromFieldPath: spec.managedNodeGroups.amiType
           toFieldPath: spec.forProvider.amiType
-        - fromFieldPath: spec.parameters.subnetIds
-          toFieldPath: spec.forProvider.subnets
+        - fromFieldPath: spec.parameters.networkId
+          toFieldPath: spec.forProvider.subnetSelector.matchLabels[network.awsblueprints.io/network-id]
 
     - name: eks-managed-nodegroup-iam-role
       base:

--- a/compositions/aws-provider/eks/eks-managed-node-group.yaml
+++ b/compositions/aws-provider/eks/eks-managed-node-group.yaml
@@ -9,6 +9,7 @@ metadata:
   labels:
     awsblueprints.io/provider: aws
     awsblueprints.io/environment: dev
+    awsblueprints.io/subnet-selection: id
     crossplane.io/xrd: xamazonekss.cluster.awsblueprints.io
     service: eks
 spec:
@@ -51,9 +52,7 @@ spec:
             resourcesVpcConfig:
               endpointPrivateAccess:
               endpointPublicAccess:
-              subnetIdSelector:
-                matchLabels:
-                  network.awsblueprints.io/network-id:
+              subnetIds:
           writeConnectionSecretToRef:
             namespace: crossplane-system
       patches:
@@ -63,8 +62,8 @@ spec:
           toFieldPath: metadata.annotations[crossplane.io/external-name]
         - fromFieldPath: spec.parameters.version
           toFieldPath: spec.forProvider.version
-        - fromFieldPath: spec.parameters.networkId
-          toFieldPath: spec.forProvider.resourcesVpcConfig.subnetIdSelector.matchLabels[network.awsblueprints.io/network-id]
+        - fromFieldPath: spec.parameters.subnetIds
+          toFieldPath: spec.forProvider.resourcesVpcConfig.subnetIds
         - fromFieldPath: spec.parameters.endpointPrivateAccess
           toFieldPath: spec.forProvider.resourcesVpcConfig.endpointPrivateAccess
         - fromFieldPath: spec.parameters.endpointPublicAccess
@@ -180,10 +179,7 @@ spec:
               matchControllerRef: true
               matchLabels:
                 role: managed-nodegroup
-            subnetSelector:
-              matchLabels:
-                network.awsblueprints.io/network-id:
-                visibility: private
+            subnets:
             scalingConfig:
               minSize:
               desiredSize:
@@ -209,8 +205,8 @@ spec:
           toFieldPath: spec.forProvider.instanceTypes
         - fromFieldPath: spec.managedNodeGroups.amiType
           toFieldPath: spec.forProvider.amiType
-        - fromFieldPath: spec.parameters.networkId
-          toFieldPath: spec.forProvider.subnetSelector.matchLabels[network.awsblueprints.io/network-id]
+        - fromFieldPath: spec.parameters.subnetIds
+          toFieldPath: spec.forProvider.subnets
 
     - name: eks-managed-nodegroup-iam-role
       base:

--- a/compositions/aws-provider/eks/eks-managed-node-group.yaml
+++ b/compositions/aws-provider/eks/eks-managed-node-group.yaml
@@ -89,7 +89,7 @@ spec:
           fromConnectionSecretKey: clusterCA
         - name: apiserver-endpoint
           fromConnectionSecretKey: endpoint
-        - name: value
+        - name: kubeconfig
           fromConnectionSecretKey: kubeconfig
     - name: eks-cluster-role
       base:

--- a/compositions/aws-provider/eks/eks-managed-node-group.yaml
+++ b/compositions/aws-provider/eks/eks-managed-node-group.yaml
@@ -81,9 +81,6 @@ spec:
 #          toFieldPath: status.eks.oidc
 #          policy:
 #            fromFieldPath: Optional
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.atProvider.resourcesVpcConfig.vpcId
-          toFieldPath: status.vpcId
       connectionDetails:
         - name: cluster-ca
           fromConnectionSecretKey: clusterCA

--- a/compositions/aws-provider/vpc-subnets/definition.yaml
+++ b/compositions/aws-provider/vpc-subnets/definition.yaml
@@ -35,6 +35,9 @@ spec:
             spec:
               type: object
               properties:
+                networkId:
+                  description: ID of this network which other objects can use to reference it.
+                  type: string
                 parameters:
                   description: VPC Input parameters
                   type: object
@@ -172,6 +175,7 @@ spec:
                     - providerConfigName
                     - region
               required:
+                - networkId
                 - parameters
                 - resourceConfig
           required:

--- a/compositions/aws-provider/vpc-subnets/definition.yaml
+++ b/compositions/aws-provider/vpc-subnets/definition.yaml
@@ -36,7 +36,7 @@ spec:
               type: object
               properties:
                 networkId:
-                  description: ID of this network which other objects can use to reference it.
+                  description: ID of this network which other objects can use to reference it. VPC and subnets are labelled with this ID in label 'network.awsblueprints.io/network-id'
                   type: string
                   default: ""
                 parameters:

--- a/compositions/aws-provider/vpc-subnets/definition.yaml
+++ b/compositions/aws-provider/vpc-subnets/definition.yaml
@@ -38,6 +38,7 @@ spec:
                 networkId:
                   description: ID of this network which other objects can use to reference it.
                   type: string
+                  default: ""
                 parameters:
                   description: VPC Input parameters
                   type: object
@@ -175,7 +176,6 @@ spec:
                     - providerConfigName
                     - region
               required:
-                - networkId
                 - parameters
                 - resourceConfig
           required:

--- a/compositions/aws-provider/vpc-subnets/vpc-composition-networkid.yaml
+++ b/compositions/aws-provider/vpc-subnets/vpc-composition-networkid.yaml
@@ -1,0 +1,520 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+---
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: xvpcsubnets-networkid.network.awsblueprints.io
+  labels:
+    awsblueprints.io/provider: aws
+    awsblueprints.io/environment: dev
+    awsblueprints.io/network-id: "true"
+    crossplane.io/xrd: xvpcsubnets.network.awsblueprints.io
+    service: vpcsubnet
+spec:
+  writeConnectionSecretsToNamespace: crossplane-system
+  compositeTypeRef:
+    apiVersion: network.awsblueprints.io/v1alpha1
+    kind: XVpcSubnet
+
+  patchSets:
+    - name: common-parameters
+      patches:
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.resourceConfig.providerConfigName
+          toFieldPath: spec.providerConfigRef.name
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.resourceConfig.deletionPolicy
+          toFieldPath: spec.deletionPolicy
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.resourceConfig.region
+          toFieldPath: spec.forProvider.region
+#        - type: FromCompositeFieldPath
+#          fromFieldPath: spec.resourceConfig.name
+#          toFieldPath: metadata.annotations[crossplane.io/external-name]
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.networkId
+          toFieldPath: metadata.labels[network.awsblueprints.io/network-id]
+
+  resources:
+    - name: vpc
+      base:
+        apiVersion: ec2.aws.crossplane.io/v1beta1
+        kind: VPC
+        spec:
+          forProvider:
+            amazonProvidedIpv6CidrBlock:
+            enableDnsSupport:
+            enableDnsHostNames:
+            cidrBlock:
+            instanceTenancy:
+            ipv6CidrBlock:
+            ipv6Pool:
+            tags:
+              - key: Name
+      patches:
+        - type: PatchSet
+          patchSetName: common-parameters
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.vpc-cidrBlock
+          toFieldPath: spec.forProvider.cidrBlock
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.vpc-Name
+          toFieldPath: spec.forProvider.tags[0].value
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.vpc-enableDnsSupport
+          toFieldPath: spec.forProvider.enableDnsSupport
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.vpc-enableDnsHostNames
+          toFieldPath: spec.forProvider.enableDnsHostNames
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.vpc-amazonProvidedIpv6CidrBlock
+          toFieldPath: spec.forProvider.amazonProvidedIpv6CidrBlock
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.vpc-instanceTenancy
+          toFieldPath: spec.forProvider.instanceTenancy
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.vpc-ipv6CidrBlock
+          toFieldPath: spec.forProvider.ipv6CidrBlock
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.vpc-ipv6Pool
+          toFieldPath: spec.forProvider.ipv6Pool
+# PUBLIC SUBNET1
+    - name: public-subnet1
+      base:
+        apiVersion: ec2.aws.crossplane.io/v1beta1
+        kind: Subnet
+        metadata:
+          labels:
+            type: subnet
+            visibility: public
+        spec:
+          forProvider:
+            cidrBlock:
+            ipv6CIDRBlock:
+            availabilityZone:
+            mapPublicIpOnLaunch: true
+            vpcIdSelector:
+              matchControllerRef: true
+            tags:
+              - key: Name
+              - key: kubernetes.io/role/elb
+                value: "1"
+      patches:
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.vpc-Name
+          toFieldPath: spec.forProvider.tags[0].value
+          transforms:
+            - string:
+                fmt: 'public-subnet1-%s'
+              type: string
+          policy:
+            fromFieldPath: Required
+        - type: PatchSet
+          patchSetName: common-parameters
+        - fromFieldPath: spec.parameters.publicSubnet1-cidrBlock
+          toFieldPath: spec.forProvider.cidrBlock
+        - fromFieldPath: spec.parameters.publicSubnet1-ipv6CIDRBlock
+          toFieldPath: spec.forProvider.ipv6CIDRBlock
+        - fromFieldPath: spec.parameters.publicSubnet1-availabilityZone
+          toFieldPath: spec.forProvider.availabilityZone
+        - fromFieldPath: spec.parameters.publicSubnet1-availabilityZone
+          toFieldPath: metadata.labels.zone
+# PUBLIC SUBNET2
+    - name: public-subnet2
+      base:
+        apiVersion: ec2.aws.crossplane.io/v1beta1
+        kind: Subnet
+        metadata:
+          labels:
+            type: subnet
+            visibility: public
+        spec:
+          forProvider:
+            cidrBlock:
+            ipv6CIDRBlock:
+            availabilityZone:
+            mapPublicIpOnLaunch: true
+            vpcIdSelector:
+              matchControllerRef: true
+            tags:
+              - key: Name
+              - key: kubernetes.io/role/elb
+                value: "1"
+      patches:
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.vpc-Name
+          toFieldPath: spec.forProvider.tags[0].value
+          transforms:
+            - string:
+                fmt: 'public-subnet2-%s'
+              type: string
+          policy:
+            fromFieldPath: Required
+        - type: PatchSet
+          patchSetName: common-parameters
+        - fromFieldPath: spec.parameters.publicSubnet2-cidrBlock
+          toFieldPath: spec.forProvider.cidrBlock
+        - fromFieldPath: spec.parameters.publicSubnet2-ipv6CIDRBlock
+          toFieldPath: spec.forProvider.ipv6CIDRBlock
+        - fromFieldPath: spec.parameters.publicSubnet2-availabilityZone
+          toFieldPath: spec.forProvider.availabilityZone
+        - fromFieldPath: spec.parameters.publicSubnet2-availabilityZone
+          toFieldPath: metadata.labels.zone
+# PUBLIC SUBNET3
+    - name: public-subnet3
+      base:
+        apiVersion: ec2.aws.crossplane.io/v1beta1
+        kind: Subnet
+        metadata:
+          labels:
+            type: subnet
+            visibility: public
+        spec:
+          forProvider:
+            cidrBlock:
+            ipv6CIDRBlock:
+            availabilityZone:
+            mapPublicIpOnLaunch: true
+            vpcIdSelector:
+              matchControllerRef: true
+            tags:
+              - key: Name
+              - key: kubernetes.io/role/elb
+                value: "1"
+      patches:
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.vpc-Name
+          toFieldPath: spec.forProvider.tags[0].value
+          transforms:
+            - string:
+                fmt: 'public-subnet3-%s'
+              type: string
+          policy:
+            fromFieldPath: Required
+        - type: PatchSet
+          patchSetName: common-parameters
+        - fromFieldPath: spec.parameters.publicSubnet3-cidrBlock
+          toFieldPath: spec.forProvider.cidrBlock
+        - fromFieldPath: spec.parameters.publicSubnet3-ipv6CIDRBlock
+          toFieldPath: spec.forProvider.ipv6CIDRBlock
+        - fromFieldPath: spec.parameters.publicSubnet3-availabilityZone
+          toFieldPath: spec.forProvider.availabilityZone
+        - fromFieldPath: spec.parameters.publicSubnet3-availabilityZone
+          toFieldPath: metadata.labels.zone
+# Private Subnet1
+    - name: private-subnet1
+      base:
+        apiVersion: ec2.aws.crossplane.io/v1beta1
+        kind: Subnet
+        metadata:
+          labels:
+            type: subnet
+            visibility: private
+        spec:
+          forProvider:
+            cidrBlock:
+            ipv6CIDRBlock:
+            availabilityZone:
+            mapPublicIpOnLaunch: false
+            vpcIdSelector:
+              matchControllerRef: true
+            tags:
+              - key: Name
+              - key: kubernetes.io/role/elb
+                value: "1"
+      patches:
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.vpc-Name
+          toFieldPath: spec.forProvider.tags[0].value
+          transforms:
+            - string:
+                fmt: 'private-subnet1-%s'
+              type: string
+          policy:
+            fromFieldPath: Required
+        - type: PatchSet
+          patchSetName: common-parameters
+        - fromFieldPath: spec.parameters.privateSubnet1-cidrBlock
+          toFieldPath: spec.forProvider.cidrBlock
+        - fromFieldPath: spec.parameters.privateSubnet1-ipv6CIDRBlock
+          toFieldPath: spec.forProvider.ipv6CIDRBlock
+        - fromFieldPath: spec.parameters.privateSubnet1-availabilityZone
+          toFieldPath: spec.forProvider.availabilityZone
+        - fromFieldPath:  spec.parameters.privateSubnet1-availabilityZone
+          toFieldPath: metadata.labels.zone
+# Private Subnet2
+    - name: private-subnet2
+      base:
+        apiVersion: ec2.aws.crossplane.io/v1beta1
+        kind: Subnet
+        metadata:
+          labels:
+            type: subnet
+            visibility: private
+        spec:
+          forProvider:
+            cidrBlock:
+            ipv6CIDRBlock:
+            availabilityZone:
+            mapPublicIpOnLaunch: false
+            vpcIdSelector:
+              matchControllerRef: true
+            tags:
+              - key: Name
+              - key: kubernetes.io/role/elb
+                value: "1"
+      patches:
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.vpc-Name
+          toFieldPath: spec.forProvider.tags[0].value
+          transforms:
+            - string:
+                fmt: 'private-subnet2-%s'
+              type: string
+          policy:
+            fromFieldPath: Required
+        - type: PatchSet
+          patchSetName: common-parameters
+        - fromFieldPath: spec.parameters.privateSubnet2-cidrBlock
+          toFieldPath: spec.forProvider.cidrBlock
+        - fromFieldPath: spec.parameters.privateSubnet2-ipv6CIDRBlock
+          toFieldPath: spec.forProvider.ipv6CIDRBlock
+        - fromFieldPath: spec.parameters.privateSubnet2-availabilityZone
+          toFieldPath: spec.forProvider.availabilityZone
+        - fromFieldPath:  spec.parameters.privateSubnet2-availabilityZone
+          toFieldPath: metadata.labels.zone
+# Private Subnet3
+    - name: private-subnet3
+      base:
+        apiVersion: ec2.aws.crossplane.io/v1beta1
+        kind: Subnet
+        metadata:
+          labels:
+            type: subnet
+            visibility: private
+        spec:
+          forProvider:
+            cidrBlock:
+            ipv6CIDRBlock:
+            availabilityZone:
+            mapPublicIpOnLaunch: false
+            vpcIdSelector:
+              matchControllerRef: true
+            tags:
+              - key: Name
+              - key: kubernetes.io/role/elb
+                value: "1"
+      patches:
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.vpc-Name
+          toFieldPath: spec.forProvider.tags[0].value
+          transforms:
+            - string:
+                fmt: 'private-subnet3-%s'
+              type: string
+          policy:
+            fromFieldPath: Required
+        - type: PatchSet
+          patchSetName: common-parameters
+        - fromFieldPath: spec.parameters.privateSubnet3-cidrBlock
+          toFieldPath: spec.forProvider.cidrBlock
+        - fromFieldPath: spec.parameters.privateSubnet3-ipv6CIDRBlock
+          toFieldPath: spec.forProvider.ipv6CIDRBlock
+        - fromFieldPath: spec.parameters.privateSubnet3-availabilityZone
+          toFieldPath: spec.forProvider.availabilityZone
+        - fromFieldPath:  spec.parameters.privateSubnet3-availabilityZone
+          toFieldPath: metadata.labels.zone
+# Internet Gateway
+    - name: internetgateway
+      base:
+        apiVersion: ec2.aws.crossplane.io/v1beta1
+        kind: InternetGateway
+        metadata:
+          labels:
+            type: igw
+        spec:
+          forProvider:
+            vpcIdSelector:
+              matchControllerRef: true
+            tags:
+              - key: Name
+      patches:
+        - type: PatchSet
+          patchSetName: common-parameters
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.vpc-Name
+          toFieldPath: spec.forProvider.tags[0].value
+          transforms:
+            - string:
+                fmt: 'igw-%s'
+              type: string
+          policy:
+            fromFieldPath: Required
+# Single NAT Gateway for Private Subnets
+    - name: single-natgateway
+      base:
+        apiVersion: ec2.aws.crossplane.io/v1beta1
+        kind: NATGateway
+        metadata:
+          labels:
+            type: natgw
+        spec:
+          forProvider:
+            allocationIdSelector:
+              matchLabels:
+                type: eip
+            connectivityType:
+            subnetIdSelector:
+              matchLabels:
+                type: subnet
+                visibility: public
+            tags:
+              - key: Name
+      patches:
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.vpc-Name
+          toFieldPath: spec.forProvider.tags[0].value
+          transforms:
+            - string:
+                fmt: 'nat-gw-%s'
+              type: string
+          policy:
+            fromFieldPath: Required
+        - type: PatchSet
+          patchSetName: common-parameters
+        - fromFieldPath: spec.parameters.publicSubnet1-availabilityZone
+          toFieldPath: spec.forProvider.subnetIdSelector.matchLabels.zone
+        - fromFieldPath: spec.parameters.nat-connectivityType
+          toFieldPath: spec.forProvider.connectivityType
+# ElasticIp for NAT Gateway
+    - name: elastic-ip
+      base:
+        apiVersion: ec2.aws.crossplane.io/v1beta1
+        kind: Address
+        metadata:
+          labels:
+            type: eip
+        spec:
+          forProvider:
+            domain: vpc
+            tags:
+              - key: Name
+      patches:
+        - type: PatchSet
+          patchSetName: common-parameters
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.vpc-Name
+          toFieldPath: spec.forProvider.tags[0].value
+          transforms:
+            - string:
+                fmt: 'eip-%s'
+              type: string
+          policy:
+            fromFieldPath: Required
+# Public Route Table
+    - name: public-route-table
+      base:
+        apiVersion: ec2.aws.crossplane.io/v1beta1
+        kind: RouteTable
+        spec:
+          forProvider:
+            vpcIdSelector:
+              matchControllerRef: true
+            routes:
+              - destinationCidrBlock: 0.0.0.0/0
+                gatewayIdSelector:
+                  matchLabels:
+                    type: igw
+            associations:
+              - subnetIdSelector:
+                  matchControllerRef: true
+                  matchLabels:
+                    type: subnet
+                    visibility: public
+                    zone:
+              - subnetIdSelector:
+                  matchControllerRef: true
+                  matchLabels:
+                    type: subnet
+                    visibility: public
+                    zone:
+              - subnetIdSelector:
+                  matchControllerRef: true
+                  matchLabels:
+                    type: subnet
+                    visibility: public
+                    zone:
+            tags:
+              - key: Name
+      patches:
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.vpc-Name
+          toFieldPath: spec.forProvider.tags[0].value
+          transforms:
+            - string:
+                fmt: 'public-route-%s'
+              type: string
+          policy:
+            fromFieldPath: Required
+        - type: PatchSet
+          patchSetName: common-parameters
+        - fromFieldPath: spec.parameters.publicSubnet1-availabilityZone
+          toFieldPath: spec.forProvider.associations[0].subnetIdSelector.matchLabels.zone
+        - fromFieldPath: spec.parameters.publicSubnet2-availabilityZone
+          toFieldPath: spec.forProvider.associations[1].subnetIdSelector.matchLabels.zone
+        - fromFieldPath: spec.parameters.publicSubnet3-availabilityZone
+          toFieldPath: spec.forProvider.associations[2].subnetIdSelector.matchLabels.zone
+# Private Route Table
+    - name: private-route-table
+      base:
+        apiVersion: ec2.aws.crossplane.io/v1beta1
+        kind: RouteTable
+        spec:
+          forProvider:
+            vpcIdSelector:
+              matchControllerRef: true
+            routes:
+              - destinationCidrBlock: 0.0.0.0/0
+                natGatewayIdSelector:
+                  matchLabels:
+                    type: natgw
+            associations:
+              - subnetIdSelector:
+                  matchControllerRef: true
+                  matchLabels:
+                    type: subnet
+                    visibility: private
+                    zone:
+              - subnetIdSelector:
+                  matchControllerRef: true
+                  matchLabels:
+                    type: subnet
+                    visibility: private
+                    zone:
+              - subnetIdSelector:
+                  matchControllerRef: true
+                  matchLabels:
+                    type: subnet
+                    visibility: private
+                    zone:
+            tags:
+              - key: Name
+      patches:
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.vpc-Name
+          toFieldPath: spec.forProvider.tags[0].value
+          transforms:
+            - string:
+                fmt: 'private-route-%s'
+              type: string
+          policy:
+            fromFieldPath: Required
+        - type: PatchSet
+          patchSetName: common-parameters
+        - fromFieldPath: spec.parameters.privateSubnet1-availabilityZone
+          toFieldPath: spec.forProvider.associations[0].subnetIdSelector.matchLabels.zone
+        - fromFieldPath: spec.parameters.privateSubnet2-availabilityZone
+          toFieldPath: spec.forProvider.associations[1].subnetIdSelector.matchLabels.zone
+        - fromFieldPath: spec.parameters.privateSubnet3-availabilityZone
+          toFieldPath: spec.forProvider.associations[2].subnetIdSelector.matchLabels.zone

--- a/compositions/aws-provider/vpc-subnets/vpc-composition.yaml
+++ b/compositions/aws-provider/vpc-subnets/vpc-composition.yaml
@@ -8,6 +8,7 @@ metadata:
   labels:
     awsblueprints.io/provider: aws
     awsblueprints.io/environment: dev
+    awsblueprints.io/network-id: "false"
     crossplane.io/xrd: xvpcsubnets.network.awsblueprints.io
     service: vpcsubnet
 spec:
@@ -31,9 +32,6 @@ spec:
 #        - type: FromCompositeFieldPath
 #          fromFieldPath: spec.resourceConfig.name
 #          toFieldPath: metadata.annotations[crossplane.io/external-name]
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.networkId
-          toFieldPath: metadata.labels[network.awsblueprints.io/network-id]
 
   resources:
     - name: vpc

--- a/compositions/aws-provider/vpc-subnets/vpc-composition.yaml
+++ b/compositions/aws-provider/vpc-subnets/vpc-composition.yaml
@@ -31,6 +31,9 @@ spec:
 #        - type: FromCompositeFieldPath
 #          fromFieldPath: spec.resourceConfig.name
 #          toFieldPath: metadata.annotations[crossplane.io/external-name]
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.networkId
+          toFieldPath: metadata.labels[network.awsblueprints.io/network-id]
 
   resources:
     - name: vpc

--- a/examples/aws-provider/composite-resources/eks/eks-claim.yaml
+++ b/examples/aws-provider/composite-resources/eks/eks-claim.yaml
@@ -33,6 +33,7 @@ spec:
     matchLabels:
       awsblueprints.io/provider: aws
       awsblueprints.io/environment: dev
+      awsblueprints.io/subnet-selection: label
       service: eks
   resourceConfig:
     providerConfigName: aws-provider-config

--- a/examples/aws-provider/composite-resources/eks/eks-claim.yaml
+++ b/examples/aws-provider/composite-resources/eks/eks-claim.yaml
@@ -16,7 +16,7 @@
 #----------------------------------------------------------------------------------
 # This example resource creates the following resources
 #     1. EKS Cluster
-#     2. EkS CLuster IAM Role
+#     2. EKS Cluster IAM Role
 #     3. Attaches EKS Cluster Policies to the IAM Role
 #     4. EKS Managed Node group
 #     5. IAM Role for EKS Managed Node group
@@ -33,7 +33,7 @@ spec:
     matchLabels:
       awsblueprints.io/provider: aws
       awsblueprints.io/environment: dev
-      awsblueprints.io/subnet-selection: label
+      awsblueprints.io/subnet-selection: id
       service: eks
   resourceConfig:
     providerConfigName: aws-provider-config
@@ -43,8 +43,10 @@ spec:
     version: "1.21"
     endpointPrivateAccess: false
     endpointPublicAccess: true
-    # networkId is used to select subnets through label 'network.awsblueprints.io/network-id'
-    networkId: dev-net
+    subnetIds: # Update your subnet ids
+      - "subnet-abc"
+      - "subnet-def"
+      - "subnet-ghi"
   managedNodeGroups:
     minSize: 2
   writeConnectionSecretToRef:

--- a/examples/aws-provider/composite-resources/eks/eks-claim.yaml
+++ b/examples/aws-provider/composite-resources/eks/eks-claim.yaml
@@ -42,10 +42,8 @@ spec:
     version: "1.21"
     endpointPrivateAccess: false
     endpointPublicAccess: true
-    subnetIds: # Update your subnet ids
-      - "subnet-abc"
-      - "subnet-def"
-      - "subnet-ghi"
+    # networkId is used to select subnets through label 'network.awsblueprints.io/network-id'
+    networkId: dev-net
   managedNodeGroups:
     minSize: 2
   writeConnectionSecretToRef:

--- a/examples/aws-provider/composite-resources/vpc-subnets-eks/vpc-subnets-eks-claims.yaml
+++ b/examples/aws-provider/composite-resources/vpc-subnets-eks/vpc-subnets-eks-claims.yaml
@@ -1,0 +1,90 @@
+# Run `kubectl apply -f vpc-subnets-eks-claims.yaml` to test this example once you bootstrap the EKS cluster with Crossplane and AWS Provider
+
+# This example resource creates the following resources through the xplane-vpc-subnets claim
+#     1. VPC
+#     2. Public Subnet
+#     3. Private Subnet
+#     4. Internet Gateway
+#     5. NAT Gateway
+#     6. EIP for NAT gateway
+#     7. Public Route Table for IGW
+#     8. Private Route Table for NAT GW
+#
+# and the following resources through the xplane-eks-cluster claim
+#     1. EKS Cluster
+#     2. EKS CLuster IAM Role
+#     3. Attaches EKS Cluster Policies to the IAM Role
+#     4. EKS Managed Node group
+#     5. IAM Role for EKS Managed Node group
+#     6. Attaches EKS Managed Node Policies to the IAM Role
+#
+# The 'networkId' parameters are used to dynamically configures EKS subnet selection.
+
+---
+apiVersion: network.awsblueprints.io/v1alpha1
+kind: vpcSubnet
+metadata:
+  name: xplane-vpc-subnets
+  namespace: default
+spec:
+  compositionSelector:
+    matchLabels:
+      awsblueprints.io/provider: aws
+      awsblueprints.io/environment: dev
+      awsblueprints.io/network-id: "true"
+      service: vpcsubnet
+  resourceConfig:
+    providerConfigName: sandbox-account
+    region: eu-central-1
+  # networkId is propagated to subnet label 'network.awsblueprints.io/network-id'
+  networkId: dev-net
+  parameters:
+    #vpc input
+    vpc-Name: xplane-vpc
+    vpc-cidrBlock: "10.20.0.0/17"   # 32768 IPs
+    vpc-amazonProvidedIpv6CidrBlock: false
+    #public subnet1
+    publicSubnet1-cidrBlock: "10.20.0.0/21" # 2048 IPs
+    publicSubnet1-availabilityZone: eu-central-1a
+    #public subnet2
+    publicSubnet2-cidrBlock: "10.20.8.0/21" # 2048 IPs
+    publicSubnet2-availabilityZone: eu-central-1b
+    #public subnet3
+    publicSubnet3-cidrBlock: "10.20.16.0/21" # 2048 IPs
+    publicSubnet3-availabilityZone: eu-central-1c
+    #private subnet1
+    privateSubnet1-cidrBlock: "10.20.64.0/21" # 2048 IPs
+    privateSubnet1-availabilityZone: eu-central-1a
+    #private subnet2
+    privateSubnet2-cidrBlock: "10.20.72.0/21" # 2048 IPs
+    privateSubnet2-availabilityZone: eu-central-1b
+    #private subnet3
+    privateSubnet3-cidrBlock: "10.20.80.0/21" # 2048 IPs
+    privateSubnet3-availabilityZone: eu-central-1c
+---
+apiVersion: cluster.awsblueprints.io/v1alpha1
+kind: amazonEks
+metadata:
+  name: xplane-eks-cluster
+  namespace: default
+spec:
+  compositionSelector:
+    matchLabels:
+      awsblueprints.io/provider: aws
+      awsblueprints.io/environment: dev
+      awsblueprints.io/subnet-selection: label
+      service: eks
+  resourceConfig:
+    providerConfigName: sandbox-account
+    region: eu-central-1
+  parameters:
+    #EKS Input parameters
+    version: "1.21"
+    endpointPrivateAccess: false
+    endpointPublicAccess: true
+    # networkId is used to select subnets through label 'network.awsblueprints.io/network-id'
+    networkId: dev-net
+  managedNodeGroups:
+    minSize: 2
+  writeConnectionSecretToRef:
+    name: xplane-eks-cluster

--- a/examples/aws-provider/composite-resources/vpc-subnets/vpc-subnets-claim.yaml
+++ b/examples/aws-provider/composite-resources/vpc-subnets/vpc-subnets-claim.yaml
@@ -24,13 +24,11 @@ spec:
     matchLabels:
       awsblueprints.io/provider: aws
       awsblueprints.io/environment: dev
-      awsblueprints.io/network-id: "true"
+      awsblueprints.io/network-id: "false"
       service: vpcsubnet
   resourceConfig:
     providerConfigName: aws-provider-config
     region: eu-west-1
-  # networkId is propagated to subnet label 'network.awsblueprints.io/network-id'
-  networkId: dev-net
   parameters:
     #vpc input
     vpc-Name: xplane-vpc

--- a/examples/aws-provider/composite-resources/vpc-subnets/vpc-subnets-claim.yaml
+++ b/examples/aws-provider/composite-resources/vpc-subnets/vpc-subnets-claim.yaml
@@ -24,6 +24,7 @@ spec:
     matchLabels:
       awsblueprints.io/provider: aws
       awsblueprints.io/environment: dev
+      awsblueprints.io/network-id: "true"
       service: vpcsubnet
   resourceConfig:
     providerConfigName: aws-provider-config

--- a/examples/aws-provider/composite-resources/vpc-subnets/vpc-subnets-claim.yaml
+++ b/examples/aws-provider/composite-resources/vpc-subnets/vpc-subnets-claim.yaml
@@ -28,6 +28,8 @@ spec:
   resourceConfig:
     providerConfigName: aws-provider-config
     region: eu-west-1
+  # networkId is propagated to subnet label 'network.awsblueprints.io/network-id'
+  networkId: dev-net
   parameters:
     #vpc input
     vpc-Name: xplane-vpc


### PR DESCRIPTION
### What does this PR do?

This PR allows the composition in `compositions/aws-provider/eks` to use labels for automatically selecting subnets and replaces the current approach where subnet IDs manually needs to be inserted into the list of subnets. See also issue #32 

### Motivation

The EKS cluster composition in `compositions/aws-provider/eks` require manual specification of subnet Ids. In Kubernetes, labels are typically used to reference resources, i.e. labelling subnets and using the `resourcesVpcConfig.subnetIdSelector.matchLabels` feature of the `cluster.eks.crossplane.io` resource would be more convenient and less error prone. Prior art for this can be found in https://github.com/upbound/platform-ref-aws

The implementation in this PR implements the following

- Adds a new parameter `networkId` to the `xvpcsubnets` composition, which is propagated to the subnet label `network.awsblueprints.io/network-id`. The idea behind NOT using the VPC name is that this is a logical network name and may consist of more than a VPC. The label use dash-case as is common for Kubernetes labels.
- Similarly adds a `networkId` to the `xamazoneks` composition and which is used for subnet selection in the cluster `resourcesVpcConfig` settings and similarly for the node group.
- Updates example claims with the `networkId` parameter.

### More

- [X ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)

- [X ] Yes, I have added a new example under [examples](https://github.com/aws-samples/crossplane-aws-blueprints/tree/main/examples) to support my PR  (partly, since this PR updates existing examples)

- [ ] Yes, I have updated the [docs](https://github.com/aws-samples/crossplane-aws-blueprints/tree/main/doc) for this feature

- [X ] Yes, I have linked to an issue or feature request (applicable to PRs that solves a bug or a feature request)

**Note**:
 - Not all the PRs require examples and docs
 - We prefer small, well tested pull requests. Please ensure your pull requests are self-contained, and commits are squashed

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

This implementation was inspired by https://github.com/upbound/platform-ref-aws