### PR TITLE
add gatekeeper example to enforce provider config usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Crossplane can be configured to publish secrets external to the cluster in which
 
 - Try it out with [this guide](doc/multi-tenant.md)
 
+✅   Checkout example [Gatekeeper configurations](./examples/gatekeeper/).
+
 ## Learn More
 
 - [Amazon EKS](https://aws.amazon.com/eks/)

--- a/examples/gatekeeper/provider-config-ns/kustomization.yaml
+++ b/examples/gatekeeper/provider-config-ns/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - template.yaml

--- a/examples/gatekeeper/provider-config-ns/samples/allowed.yaml
+++ b/examples/gatekeeper/provider-config-ns/samples/allowed.yaml
@@ -1,0 +1,17 @@
+apiVersion: s3.aws.crossplane.io/v1beta1
+kind: Bucket
+metadata:
+  annotations:
+    crossplane.io/composition-resource-name: s3-bucket
+  labels:
+    crossplane.io/claim-name: standard-object-storage
+    crossplane.io/claim-namespace: application1
+    crossplane.io/composite: standard-object-storage-zlss9
+  name: standard-object-storage-zlss9-tkqgs
+spec:
+  deletionPolicy: Delete
+  forProvider:
+    acl: private
+  providerConfigRef:
+    name: application1-provider-config
+

--- a/examples/gatekeeper/provider-config-ns/samples/constraint.yaml
+++ b/examples/gatekeeper/provider-config-ns/samples/constraint.yaml
@@ -1,0 +1,10 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: ProviderConfigMismatch
+metadata:
+  name: crossplane-provider-config-ns
+spec:
+  match:
+    scope: "Cluster"
+    kinds:
+      - apiGroups: ["*"] # not possible to partial match. e.g. *.aws.crossplane.io does not work.
+        kinds: ["*"]

--- a/examples/gatekeeper/provider-config-ns/samples/missing_claim_disallowed.yaml
+++ b/examples/gatekeeper/provider-config-ns/samples/missing_claim_disallowed.yaml
@@ -1,0 +1,16 @@
+
+apiVersion: s3.aws.crossplane.io/v1beta1
+kind: Bucket
+metadata:
+  annotations:
+    crossplane.io/composition-resource-name: s3-bucket
+  labels:
+    something: else
+  name: standard-object-storage-zlss9-tkqgs
+spec:
+  deletionPolicy: Delete
+  forProvider:
+    acl: private
+  providerConfigRef:
+    name: invalid
+

--- a/examples/gatekeeper/provider-config-ns/samples/namespace_mismatch_disallowed.yaml
+++ b/examples/gatekeeper/provider-config-ns/samples/namespace_mismatch_disallowed.yaml
@@ -1,0 +1,23 @@
+
+apiVersion: s3.aws.crossplane.io/v1beta1
+kind: Bucket
+metadata:
+  annotations:
+    crossplane.io/composition-resource-name: s3-bucket
+  labels:
+    crossplane.io/claim-name: standard-object-storage
+    crossplane.io/claim-namespace: application1
+    crossplane.io/composite: standard-object-storage-zlss9
+  name: standard-object-storage-zlss9-tkqgs
+  ownerReferences:
+    - apiVersion: awsblueprints.io/v1alpha1
+      controller: true
+      kind: XObjectStorage
+      name: standard-object-storage-zlss9
+      uid: fa2fa596-2106-4c6c-898a-8976a4686489
+spec:
+  deletionPolicy: Delete
+  forProvider:
+    acl: private
+  providerConfigRef:
+    name: invalid

--- a/examples/gatekeeper/provider-config-ns/samples/not_applicable_allowed.yaml
+++ b/examples/gatekeeper/provider-config-ns/samples/not_applicable_allowed.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: static-web
+  labels:
+    role: myrole
+spec:
+  containers:
+    - name: web
+      image: nginx
+      ports:
+        - name: web
+          containerPort: 80
+          protocol: TCP
+

--- a/examples/gatekeeper/provider-config-ns/suite.yaml
+++ b/examples/gatekeeper/provider-config-ns/suite.yaml
@@ -1,0 +1,25 @@
+kind: Suite
+apiVersion: test.gatekeeper.sh/v1alpha1
+metadata:
+  name: block-namespace-mismatch
+tests:
+- name: block-namespace-mismatch
+  template: template.yaml
+  constraint: samples/constraint.yaml
+  cases:
+  - name: missing-claim-namespace
+    object: samples/missing_claim_disallowed.yaml
+    assertions:
+    - violations: yes
+  - name: provider-config-name-mismatch
+    object: samples/namespace_mismatch_disallowed.yaml
+    assertions:
+    - violations: yes
+  - name: allowed
+    object: samples/allowed.yaml
+    assertions:
+    - violations: no
+  - name: allowed-not-applicable
+    object: samples/not_applicable_allowed.yaml
+    assertions:
+    - violations: no

--- a/examples/gatekeeper/provider-config-ns/template.yaml
+++ b/examples/gatekeeper/provider-config-ns/template.yaml
@@ -1,0 +1,44 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: providerconfigmismatch
+  annotations:
+    description: >-
+      Disallows ProviderConfig name mismatch. ProviderConfig must be <NAMESPACE>-provider-config
+spec:
+  crd:
+    spec:
+      names:
+        kind: ProviderConfigMismatch
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package providerconfigmismatch
+
+        # this is necessary since there are no way to match based on glob expressions within constrains.
+        default should_process = false
+        should_process = true {
+          re_match("^.*.aws.crossplane.io$", input.review.kind.group)
+        }
+
+        violation[{"msg": msg}] {
+          should_process
+          not input.review.object.metadata.labels
+          msg := "label not present"
+        }
+
+        # claim namespace label must be present. this means you cannot create managed resource directly and composite resource cannot be created unless excluded by constrains.
+        violation[{"msg": msg}] {
+          should_process
+          not input.review.object.metadata.labels["crossplane.io/claim-namespace"]
+          msg := "crossplane claim ns not present"
+        }
+
+        violation[{"msg": msg}] {
+          should_process
+          claimNS := input.review.object.metadata.labels["crossplane.io/claim-namespace"]
+          expected := sprintf("%v-provider-config", [claimNS])
+          expected != input.review.object.spec.providerConfigRef.name
+          msg := sprintf("provider config name must be <NAMESPACE>-provider-config. expected: %v, received %v", [expected, input.review.object.spec.providerConfigRef.name])
+        }
+


### PR DESCRIPTION
### What does this PR do?

Adds a Gatekeeper example for enforcing the provider config name selection based on claim's namespace.


### Motivation




### More

- [x] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)

- [x] Yes, I have added a new example under [examples](https://github.com/aws-samples/crossplane-aws-blueprints/tree/main/examples) to support my PR

- [x] Yes, I have updated the [docs](https://github.com/aws-samples/crossplane-aws-blueprints/tree/main/doc) for this feature

- [x] Yes, I have linked to an issue or feature request (applicable to PRs that solves a bug or a feature request)

**Note**:
 - Not all the PRs require examples and docs
 - We prefer small, well tested pull requests. Please ensure your pull requests are self-contained, and commits are squashed

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
