### PR TITLE
add gatekeeper example readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Compositions can be nested to further define and abstract application specific n
 
 Crossplane can be configured to publish secrets external to the cluster in which it runs. 
 
-- Try it out with [this guide](doc/multi-tenant.md)
+- Try it out with [this guide](doc/vault-integration.md)
 
 ✅   Checkout example [Gatekeeper configurations](./examples/gatekeeper/).
 

--- a/examples/gatekeeper/provider-config-ns/README.md
+++ b/examples/gatekeeper/provider-config-ns/README.md
@@ -1,0 +1,11 @@
+### Provider Config name enforcement based on namespace
+
+This example Gatekeeper policy enforces provider config name based on namespaces. For example, if the claim is created in a namespace called `test`, the provider config name used for this managed resource should be `test-provider-config`. See the [template file](./template.yaml) and the [constraint file](./samples/constraint.yaml) for more details.
+
+Examples and test cases are available under the `samples` directory. Tests can be ran using the [gator cli](https://open-policy-agent.github.io/gatekeeper/website/docs/gator/). 
+
+To run tests for this example run: 
+```bash
+cd examples/gatekeeper/provider-config-ns/
+gator verify . -v
+```


### PR DESCRIPTION
### What does this PR do?

Adding a readme to the gatekeeper example and fixes the link to vault integration example

