### PR TITLE
Removes comment separators at the beginning

### DIFF
--- a/compositions/aws-provider/eks/eks-managed-node-group-subnet-labels.yaml
+++ b/compositions/aws-provider/eks/eks-managed-node-group-subnet-labels.yaml
@@ -1,7 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: MIT-0
 
----
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:

--- a/compositions/aws-provider/eks/eks-managed-node-group.yaml
+++ b/compositions/aws-provider/eks/eks-managed-node-group.yaml
@@ -1,7 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: MIT-0
 
----
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:

--- a/compositions/aws-provider/vpc-subnets/vpc-composition-networkid.yaml
+++ b/compositions/aws-provider/vpc-subnets/vpc-composition-networkid.yaml
@@ -1,6 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: MIT-0
----
+
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:

--- a/compositions/aws-provider/vpc-subnets/vpc-composition.yaml
+++ b/compositions/aws-provider/vpc-subnets/vpc-composition.yaml
@@ -1,6 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: MIT-0
----
+
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:

--- a/compositions/aws-provider/vpc/vpc-composition.yaml
+++ b/compositions/aws-provider/vpc/vpc-composition.yaml
@@ -1,6 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: MIT-0
----
+
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:


### PR DESCRIPTION
Signed-off-by: Matthias Luebken <matthias.luebken@gmail.com>

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Removes the yaml doc separator at the beginning of the yamls. While this is valid yaml definition they are considered optional: (https://yaml.org/spec/1.0/#id2561718) 

### Motivation
<!-- What inspired you to submit this pull request? -->

We are running into an [issue](https://github.com/crossplane/crossplane-runtime/issues/356) when [building a configuration package]( https://github.com/luebken/crossplane-aws-blueprints/pull/3#issuecomment-1256407271). The current xpkg spec doesn't consider it a valid spec.

### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)

- [ ] Yes, I have added a new example under [examples](https://github.com/aws-samples/crossplane-aws-blueprints/tree/main/examples) to support my PR

- [ ] Yes, I have updated the [docs](https://github.com/aws-samples/crossplane-aws-blueprints/tree/main/doc) for this feature

- [ ] Yes, I have linked to an issue or feature request (applicable to PRs that solves a bug or a feature request)

**Note**:
 - Not all the PRs require examples and docs
 - We prefer small, well tested pull requests. Please ensure your pull requests are self-contained, and commits are squashed

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
