### PR TITLE
Configuration package definitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .terraform/
 kubeconfig_*
 local_tf_state/
+*.xpkg

--- a/compositions/README.md
+++ b/compositions/README.md
@@ -62,5 +62,5 @@ kind: Configuration
 metadata:
   name: crossplane-aws-blueprints
 spec:
-  package: example-docker/crossplane-aws-blueprints/upbound/crossplane-aws-blueprints:v0.0.1
+  package: example-docker/crossplane-aws-blueprints:v0.0.1
 ```

--- a/compositions/README.md
+++ b/compositions/README.md
@@ -55,3 +55,12 @@ And this is how you would install that package on to your control plane:
 ```shell
 kubectl crossplane install configuration $REPO:v0.0.1
 ```
+or apply a configuration declaration:
+```yaml
+apiVersion: pkg.crossplane.io/v1
+kind: Configuration
+metadata:
+  name: crossplane-aws-blueprints
+spec:
+  package: example-docker/crossplane-aws-blueprints/upbound/crossplane-aws-blueprints:v0.0.1
+```

--- a/compositions/README.md
+++ b/compositions/README.md
@@ -46,12 +46,12 @@ Each folder contains a Crossplane configuration [package](https://crossplane.io/
 This is how you build and push the crossplane-aws-blueprints configuration package:
 ```shell
 cd aws-provider
-export REPO=<some-oci-repository>
+export REPO=example-docker/crossplane-aws-blueprints
 kubectl crossplane build configuration
-kubectl crossplane push configuration $REPO/crossplane-aws-blueprints:v0.0.1
+kubectl crossplane push configuration $REPO:v0.0.1
 ```
 
 And this is how you would install that package on to your control plane:
 ```shell
-kubectl crossplane install configuration $REPO/crossplane-aws-blueprints:v0.0.1
+kubectl crossplane install configuration $REPO:v0.0.1
 ```

--- a/compositions/README.md
+++ b/compositions/README.md
@@ -38,3 +38,20 @@ Deploys VPC claim resource which uses the above composition.
 ```shell
 kubectl apply -f examples/terrajet-aws-provider/composition-resources/vpc.yaml
 ```
+
+# Configuration Packages
+
+Each folder contains a Crossplane configuration [package](https://crossplane.io/docs/v1.9/concepts/packages.html) definition which bundles all compositions into a single OCI image. 
+
+This is how you build and push the crossplane-aws-blueprints configuration package:
+```shell
+cd aws-provider
+export REPO=<some-oci-repository>
+kubectl crossplane build configuration
+kubectl crossplane push configuration $REPO/crossplane-aws-blueprints:v0.0.1
+```
+
+And this is how you would install that package on to your control plane:
+```shell
+kubectl crossplane install configuration $REPO/crossplane-aws-blueprints:v0.0.1
+```

--- a/compositions/aws-provider/crossplane.yaml
+++ b/compositions/aws-provider/crossplane.yaml
@@ -1,0 +1,17 @@
+apiVersion: meta.pkg.crossplane.io/v1
+kind: Configuration
+metadata:
+  name: crossplane-aws-blueprints
+  annotations:
+    friendly-name.meta.crossplane.io: "AWS Blueprints for Crossplane"
+    meta.crossplane.io/source: https://github.com/aws-samples/crossplane-aws-blueprints
+    meta.crossplane.io/license: MIT-0
+    meta.crossplane.io/maintainer: AWS OSS team
+    meta.crossplane.io/description: AWS Crossplane Blueprints by the AWS OSS team
+    meta.crossplane.io/readme: "AWS Crossplane Blueprints is an open source repo to bootstrap EKS Clusters and provision AWS resources with a library of Crossplane Compositions (XRs) with Composite Resource Definitions (XRDs). Compositions in this repository enable platform teams to define and offer bespoke AWS infrastructure APIs to the teams of application developers based on predefined Composite Resources (XRs), encompassing one or more of AWS Managed Resources (MRs). Note AWS Blueprints for Crossplane is under active development and should be considered a pre-production framework."
+spec:
+  crossplane:
+    version: ">=v1.9.1"
+  dependsOn:
+    - provider: crossplane/provider-aws
+      version: ">=v0.31.0"

--- a/compositions/terrajet-aws-provider/crossplane.yaml
+++ b/compositions/terrajet-aws-provider/crossplane.yaml
@@ -1,0 +1,17 @@
+apiVersion: meta.pkg.crossplane.io/v1
+kind: Configuration
+metadata:
+  name: crossplane-aws-blueprints
+  annotations:
+    friendly-name.meta.crossplane.io: "AWS Blueprints for Crossplane"
+    meta.crossplane.io/source: https://github.com/aws-samples/crossplane-aws-blueprints
+    meta.crossplane.io/license: MIT-0
+    meta.crossplane.io/maintainer: AWS OSS team
+    meta.crossplane.io/description: AWS Crossplane Blueprints by the AWS OSS team
+    meta.crossplane.io/readme: "AWS Crossplane Blueprints is an open source repo to bootstrap EKS Clusters and provision AWS resources with a library of Crossplane Compositions (XRs) with Composite Resource Definitions (XRDs). Compositions in this repository enable platform teams to define and offer bespoke AWS infrastructure APIs to the teams of application developers based on predefined Composite Resources (XRs), encompassing one or more of AWS Managed Resources (MRs). Note AWS Blueprints for Crossplane is under active development and should be considered a pre-production framework."
+spec:
+  crossplane:
+    version: ">=v1.9.1"
+  dependsOn:
+    - provider: crossplane/provider-jet-aws
+      version: ">=v0.5.0-preview"


### PR DESCRIPTION
Signed-off-by: Matthias Luebken <matthias.luebken@gmail.com>

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Adds two configuration package definitions for the aws-provider and the terrajet-aws-provider and a readme addition that describes on how to build them. See https://crossplane.io/docs/v1.9/concepts/packages.html

### Motivation
<!-- What inspired you to submit this pull request? -->

Configuration packages are a convenient way to bundle and distribute crossplane definitions. Adding them here promotes this concept to the AWS blueprint community and might encourage further usage.


### More

- [x] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)

- [ ] Yes, I have added a new example under [examples](https://github.com/aws-samples/crossplane-aws-blueprints/tree/main/examples) to support my PR

- [ ] Yes, I have updated the [docs](https://github.com/aws-samples/crossplane-aws-blueprints/tree/main/doc) for this feature

- [ ] Yes, I have linked to an issue or feature request (applicable to PRs that solves a bug or a feature request)

**Note**:
 - Not all the PRs require examples and docs
 - We prefer small, well tested pull requests. Please ensure your pull requests are self-contained, and commits are squashed

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
