### PR TITLE
ensure deletion policy is propagated for k8s resources

### DIFF
--- a/compositions/aws-provider/eks/autoscaler.yaml
+++ b/compositions/aws-provider/eks/autoscaler.yaml
@@ -34,6 +34,9 @@ spec:
           toFieldPath: spec.providerConfigRef.name
           policy:
             fromFieldPath: Required
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.resourceConfig.deletionPolicy
+          toFieldPath: spec.deletionPolicy
   resources:
     - name: vpc
       base:
@@ -670,8 +673,10 @@ spec:
                 fmt: "eks-aws-auth-%s"
           policy:
             fromFieldPath: Required
-        - type: PatchSet
-          patchSetName: k8s-config
+        - fromFieldPath: metadata.labels[crossplane.io/claim-name]
+          toFieldPath: spec.providerConfigRef.name
+          policy:
+            fromFieldPath: Required
         - type: CombineFromComposite
           combine:
             strategy: string


### PR DESCRIPTION
### What does this PR do?

Ensures deletion policy is propagated to K8s resources for the autoscaler composition, except for the aws-auth cm.



