### PR TITLE
feat: create cognito userpool client that exports both client ID and …

### DIFF
--- a/compositions/upbound-aws-provider/cognito-userpool-client/definition.yaml
+++ b/compositions/upbound-aws-provider/cognito-userpool-client/definition.yaml
@@ -1,0 +1,46 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  name: xupcs.composite.awsblueprints.io
+spec:
+  group: composite.awsblueprints.io
+  names:
+    kind: XUserpoolClient
+    plural: xupcs
+  claimNames:
+    kind: UserpoolClient
+    plural: upcs
+  versions:
+    - name: v1alpha1
+      served: true
+      referenceable: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                parameters:
+                  description: List of parameters reused in the composition to produce desired resources.
+                  type: object
+                  properties:
+                    name:
+                      description: Name for the user pool client.
+                      type: string
+                    namespace:
+                      description: Namespace to create the user pool client in.
+                      type: string
+                    callback:
+                      description: Callback URL to replace the placeholder in the composition.
+                      type: string
+                    userPoolId:
+                      description: User pool ID to create the client in.
+                      type: string
+            status:
+              description: List of status fields to be reused by the composition.
+              type: object
+              properties:
+                clientId:
+                  description: Client ID of the user pool client.
+                  type: string

--- a/compositions/upbound-aws-provider/cognito-userpool-client/kustomization.yaml
+++ b/compositions/upbound-aws-provider/cognito-userpool-client/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - definition.yaml
+  - cognito-userpool-client.yaml

--- a/compositions/upbound-aws-provider/cognito-userpool-client/userpool-client.yaml
+++ b/compositions/upbound-aws-provider/cognito-userpool-client/userpool-client.yaml
@@ -1,0 +1,139 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: xupcs.composite.awsblueprints.io
+spec:
+  # Placeholder. Will be replaced by the namespace provided as input
+  writeConnectionSecretsToNamespace: default
+  compositeTypeRef:
+    apiVersion: composite.awsblueprints.io/v1alpha1
+    kind: XUserpoolClient
+  resources:
+    - name: userpoolclient
+      base:
+        apiVersion: cognitoidp.aws.upbound.io/v1beta1
+        kind: UserPoolClient
+        metadata:
+          # Placeholder. Will be replaced by the name provided as input
+          name: client-0
+          # Placeholder. Will be replaced by the namespace provided as input
+          namespace: default
+        spec:
+          providerConfigRef:
+            name: upbound-aws-irsa
+          forProvider:
+            # Placeholder. Will be replaced by the name provided as input
+            name: client-0
+            # Placeholder. Will be replaced by the user pool ID provided as input
+            userPoolId: userpool-id
+            accessTokenValidity: 720
+            idTokenValidity: 720
+            region: us-east-1
+            allowedOauthFlows:
+              - code
+              - implicit
+            allowedOauthFlowsUserPoolClient: true
+            allowedOauthScopes:
+              - aws.cognito.signin.user.admin
+              - email
+              - openid
+              - phone
+              - profile
+            authSessionValidity: 3
+            # Placeholder. Will be replaced by the callback URL provided as input
+            callbackUrls:
+              - https://example.com
+            enablePropagateAdditionalUserContextData: false
+            enableTokenRevocation: true
+            explicitAuthFlows:
+              - ALLOW_ADMIN_USER_PASSWORD_AUTH
+              - ALLOW_CUSTOM_AUTH
+              - ALLOW_REFRESH_TOKEN_AUTH
+              - ALLOW_USER_SRP_AUTH
+            generateSecret: true
+            preventUserExistenceErrors: ENABLED
+            readAttributes:
+              - address
+              - birthdate
+              - email
+              - email_verified
+              - family_name
+              - gender
+              - given_name
+              - locale
+              - middle_name
+              - name
+              - nickname
+              - phone_number
+              - phone_number_verified
+              - picture
+              - preferred_username
+              - profile
+              - updated_at
+              - website
+              - zoneinfo
+            refreshTokenValidity: 30
+            supportedIdentityProviders:
+              - COGNITO
+              - Okta
+            writeAttributes:
+              - address
+              - birthdate
+              - email
+              - family_name
+              - gender
+              - given_name
+              - locale
+              - middle_name
+              - name
+              - nickname
+              - phone_number
+              - picture
+              - preferred_username
+              - profile
+              - updated_at
+              - website
+              - zoneinfo
+            tokenValidityUnits:
+              - accessToken: minutes
+                idToken: minutes
+                refreshToken: days
+          writeConnectionSecretToRef:
+            # Write the client secret as a kubernetes secret with the name provided below
+            name: cognito-userpool-client-secret
+            # placeholder. Will be replaced by the namespace provided as input
+            namespace: default
+      patches:
+        # List of patches to apply to the resource
+        - fromFieldPath: spec.parameters.name
+          toFieldPath: metadata.name
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.parameters.name
+          toFieldPath: spec.forProvider.name
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.parameters.namespace
+          toFieldPath: metadata.namespace
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.parameters.namespace
+          toFieldPath: spec.writeConnectionSecretToRef.namespace
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.parameters.callback
+          toFieldPath: spec.forProvider.callbackUrls[0]
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.parameters.userPoolId
+          toFieldPath: spec.forProvider.userPoolId
+          type: FromCompositeFieldPath
+        - fromFieldPath: status.atProvider.id
+          toFieldPath: status.clientId
+          type: ToCompositeFieldPath
+      connectionDetails:
+        # Write both the client ID and the client secret in a kubernetes secret
+        - name: client_id
+          fromFieldPath: status.atProvider.id
+        - name: client_secret
+          fromConnectionSecretKey: attribute.client_secret
+      readinessChecks:
+        - matchCondition:
+            status: "True"
+            type: Ready
+          type: MatchCondition

--- a/compositions/upbound-aws-provider/kustomization.yaml
+++ b/compositions/upbound-aws-provider/kustomization.yaml
@@ -15,3 +15,4 @@ resources:
 - sns-sqs/
 - apigw/
 - serverless-microservice/
+- cognito-userpool-client

--- a/examples/upbound-aws-provider/composite-resources/cognito-upc.yaml
+++ b/examples/upbound-aws-provider/composite-resources/cognito-upc.yaml
@@ -1,0 +1,13 @@
+apiVersion: composite.awsblueprint.io/alpha
+kind: UserpoolClient
+metadata:
+  name: rocket-userpool-client-id
+  namespace: moon
+spec:
+  writeConnectionSecretToRef:
+    name: cognito-userpool-client-details
+  parameters:
+    name: rocket
+    namespace: moon
+    callback: https://awsblueprint.io/earth/oauth_callback
+    userPoolId: us-east-1_toZMoon11


### PR DESCRIPTION
…client secret to a kubernetes secret (connection details)


### What does this PR do?

Introduces a new Crossplane Composition and an XRD for managing AWS Cognito User Pool Clients. The composition enables automated provisioning of UserPoolClient resources based on user-specified inputs and writes connection secrets for the client, including and especially both the client ID and client secret.


### Motivation

The current version of the UserPoolClient in the cognito-idp family of providers by AWS only exports client ID as a connection detail. It does not support client secret, which makes it useless if you want to reuse both of those details in other kubernetes resources such as exporting those in two SSM parameters or a secret in Secrets Manager.


### More

- [x] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)

- [x] Yes, I have added a new example under [examples](https://github.com/aws-samples/crossplane-aws-blueprints/tree/main/examples) to support my PR

- [ ] Yes, I have updated the [docs](https://github.com/aws-samples/crossplane-aws-blueprints/tree/main/doc) for this feature

- [ ] Yes, I have linked to an issue or feature request (applicable to PRs that solves a bug or a feature request)

**Note**:
 - Not all the PRs require examples and docs
 - We prefer small, well tested pull requests. Please ensure your pull requests are self-contained, and commits are squashed

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

![cognito-composite-working-example](https://github.com/user-attachments/assets/ff8f9b3f-51bc-4625-be73-7fa71c357862)

