### PR TITLE
feat: Crossplane v1.18+ support

### DIFF
--- a/compositions/upbound-aws-provider/apigw/rest.yaml
+++ b/compositions/upbound-aws-provider/apigw/rest.yaml
@@ -4,312 +4,307 @@
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
-  name: rest.apigateway.aws.upbound.awsblueprints.io
   labels:
-    awsblueprints.io/provider: aws
     awsblueprints.io/environment: dev
+    awsblueprints.io/provider: aws
     awsblueprints.io/type: rest
+  name: rest.apigateway.aws.upbound.awsblueprints.io
 spec:
   compositeTypeRef:
     apiVersion: awsblueprints.io/v1alpha1
     kind: XApiGateway
-  patchSets:
-    - name: common-fields
-      patches:
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.deletionPolicy
+  mode: Pipeline
+  pipeline:
+  - functionRef:
+      name: function-patch-and-transform
+    input:
+      apiVersion: pt.fn.crossplane.io/v1beta1
+      kind: Resources
+      patchSets:
+      - name: common-fields
+        patches:
+        - fromFieldPath: spec.resourceConfig.deletionPolicy
           toFieldPath: spec.deletionPolicy
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.providerConfigName
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.resourceConfig.providerConfigName
           toFieldPath: spec.providerConfigRef.name
-        - fromFieldPath: "metadata.name"
-          toFieldPath: "metadata.name"
-  resources:
-    - name: restapi
-      base:
-        apiVersion: apigateway.aws.upbound.io/v1beta1
-        kind: RestAPI
-        spec:
-          deletionPolicy: Delete
-          forProvider:
-            name: restApi
-            endpointConfiguration:
-            - types:
+          type: FromCompositeFieldPath
+        - fromFieldPath: metadata.name
+          toFieldPath: metadata.name
+          type: FromCompositeFieldPath
+      resources:
+      - base:
+          apiVersion: apigateway.aws.upbound.io/v1beta1
+          kind: RestAPI
+          spec:
+            deletionPolicy: Delete
+            forProvider:
+              endpointConfiguration:
+              - types:
                 - REGIONAL
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.region
+              name: restApi
+        name: restapi
+        patches:
+        - patchSetName: common-fields
+          type: PatchSet
+        - fromFieldPath: spec.resourceConfig.region
           toFieldPath: spec.forProvider.region
-        - type: FromCompositeFieldPath
-          fromFieldPath: metadata.name
+          type: FromCompositeFieldPath
+        - fromFieldPath: metadata.name
           toFieldPath: metadata.name
           transforms:
-            - type: string
-              string:
-                fmt: "%s-restapi"
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.apiDescription
+          - string:
+              fmt: '%s-restapi'
+              type: Format
+            type: string
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.apiDescription
           toFieldPath: spec.forProvider.description
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.apiName
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.apiName
           toFieldPath: spec.forProvider.name
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.openApiSpecification
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.openApiSpecification
           toFieldPath: spec.forProvider.body
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.endpointType
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.endpointType
           toFieldPath: spec.forProvider.endpointConfiguration[0].types[0]
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.atProvider.arn
+          type: FromCompositeFieldPath
+        - fromFieldPath: status.atProvider.arn
           toFieldPath: status.apigwArn
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.atProvider.executionArn
+          type: ToCompositeFieldPath
+        - fromFieldPath: status.atProvider.executionArn
           toFieldPath: status.apiExecutionArn
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.atProvider.id
+          type: ToCompositeFieldPath
+        - fromFieldPath: status.atProvider.id
           toFieldPath: status.apiId
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.atProvider.name
+          type: ToCompositeFieldPath
+        - fromFieldPath: status.atProvider.name
           toFieldPath: status.apiName
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.atProvider.executionArn
+          type: ToCompositeFieldPath
+        - fromFieldPath: status.atProvider.executionArn
           toFieldPath: status.accountId
           transforms:
-            - type: string
-              string:
-                type: Regexp
-                regexp:
-                  match: \d{12,}          
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.tags
-          toFieldPath: spec.forProvider.tags
+          - string:
+              regexp:
+                match: \d{12,}
+              type: Regexp
+            type: string
+          type: ToCompositeFieldPath
+        - fromFieldPath: spec.resourceConfig.tags
           policy:
-            mergeOptions:
-              keepMapValues: true
-
-    - name: apigw-role
-      base:
-        apiVersion: iam.aws.upbound.io/v1beta1
-        kind: Role
-        spec:
-          deletionPolicy: Delete
-          forProvider:
-            assumeRolePolicy: |
-              {
-                "Version": "2012-10-17",
-                "Statement": [
-                  {
-                    "Effect": "Allow",
-                    "Principal": {
-                      "Service": "apigateway.amazonaws.com"
-                    },
-                    "Action": "sts:AssumeRole"
-                  }
-                ]
-              }
-            path: "/"
-            managedPolicyArns:
-              - >-
-                arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields
-        - type: FromCompositeFieldPath
-          fromFieldPath: metadata.name
+            toFieldPath: MergeObjects
+          toFieldPath: spec.forProvider.tags
+          type: FromCompositeFieldPath
+      - base:
+          apiVersion: iam.aws.upbound.io/v1beta1
+          kind: Role
+          spec:
+            deletionPolicy: Delete
+            forProvider:
+              assumeRolePolicy: |
+                {
+                  "Version": "2012-10-17",
+                  "Statement": [
+                    {
+                      "Effect": "Allow",
+                      "Principal": {
+                        "Service": "apigateway.amazonaws.com"
+                      },
+                      "Action": "sts:AssumeRole"
+                    }
+                  ]
+                }
+              managedPolicyArns:
+              - arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs
+              path: /
+        name: apigw-role
+        patches:
+        - patchSetName: common-fields
+          type: PatchSet
+        - fromFieldPath: metadata.name
           toFieldPath: metadata.name
           transforms:
-            - type: string
-              string:
-                fmt: "%s-apigw-role"
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.atProvider.arn
+          - string:
+              fmt: '%s-apigw-role'
+              type: Format
+            type: string
+          type: FromCompositeFieldPath
+        - fromFieldPath: status.atProvider.arn
           toFieldPath: status.apigwRoleArn
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.atProvider.id
+          type: ToCompositeFieldPath
+        - fromFieldPath: status.atProvider.id
           toFieldPath: status.apigwRoleName
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.tags
-          toFieldPath: spec.forProvider.tags
+          type: ToCompositeFieldPath
+        - fromFieldPath: spec.resourceConfig.tags
           policy:
-            mergeOptions:
-              keepMapValues: true
-
-    - name: api-deployment
-      base:
-        apiVersion: apigateway.aws.upbound.io/v1beta1
-        kind: Deployment
-        spec:
-          deletionPolicy: Delete
-          forProvider:
-            restApiIdSelector:
-              matchControllerRef: true
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.region
+            toFieldPath: MergeObjects
+          toFieldPath: spec.forProvider.tags
+          type: FromCompositeFieldPath
+      - base:
+          apiVersion: apigateway.aws.upbound.io/v1beta1
+          kind: Deployment
+          spec:
+            deletionPolicy: Delete
+            forProvider:
+              restApiIdSelector:
+                matchControllerRef: true
+        name: api-deployment
+        patches:
+        - patchSetName: common-fields
+          type: PatchSet
+        - fromFieldPath: spec.resourceConfig.region
           toFieldPath: spec.forProvider.region
-        - type: FromCompositeFieldPath
-          fromFieldPath: metadata.name
+          type: FromCompositeFieldPath
+        - fromFieldPath: metadata.name
           toFieldPath: metadata.name
           transforms:
-            - type: string
-              string:
-                fmt: "%s-api-deployment"
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.atProvider.id
+          - string:
+              fmt: '%s-api-deployment'
+              type: Format
+            type: string
+          type: FromCompositeFieldPath
+        - fromFieldPath: status.atProvider.id
           toFieldPath: status.apigwDeploymentId
-
-    - name: api-stage
-      base:
-        apiVersion: apigateway.aws.upbound.io/v1beta1
-        kind: Stage
-        spec:
-          deletionPolicy: Delete
-          forProvider:
-            restApiIdSelector:
-              matchControllerRef: true
-            deploymentIdSelector:
-              matchControllerRef: true
-            stageName: api
-            accessLogSettings: 
+          type: ToCompositeFieldPath
+      - base:
+          apiVersion: apigateway.aws.upbound.io/v1beta1
+          kind: Stage
+          spec:
+            deletionPolicy: Delete
+            forProvider:
+              accessLogSettings:
               - destinationArn: arn:aws:logs:us-region-1:123456789012:log-group:myrestapi-abcdxyz-api-access-logs
-                format: >-
-                  { 
-                  "requestId":"$context.requestId", 
-                  "ip": "$context.identity.sourceIp", 
-                  "requestTime":"$context.requestTime", 
-                  "httpMethod":"$context.httpMethod",
-                  "routeKey":"$context.routeKey", 
-                  "status":"$context.status",
-                  "protocol":"$context.protocol", 
-                  "integrationStatus": "$context.integrationStatus",
-                  "integrationLatency": "$context.integrationLatency", 
-                  "responseLength":"$context.responseLength" 
-                  }
-            xrayTracingEnabled: true
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.region
+                format: '{  "requestId":"$context.requestId",  "ip": "$context.identity.sourceIp",  "requestTime":"$context.requestTime",  "httpMethod":"$context.httpMethod",
+                  "routeKey":"$context.routeKey",  "status":"$context.status", "protocol":"$context.protocol",  "integrationStatus":
+                  "$context.integrationStatus", "integrationLatency": "$context.integrationLatency",  "responseLength":"$context.responseLength"  }'
+              deploymentIdSelector:
+                matchControllerRef: true
+              restApiIdSelector:
+                matchControllerRef: true
+              stageName: api
+              xrayTracingEnabled: true
+        name: api-stage
+        patches:
+        - patchSetName: common-fields
+          type: PatchSet
+        - fromFieldPath: spec.resourceConfig.region
           toFieldPath: spec.forProvider.region
-        - type: FromCompositeFieldPath
-          fromFieldPath: metadata.name
+          type: FromCompositeFieldPath
+        - fromFieldPath: metadata.name
           toFieldPath: metadata.name
           transforms:
-            - type: string
-              string:
-                fmt: "%s-api-stage"
-        - type: FromCompositeFieldPath
-          fromFieldPath: status.apigwAccessLogsGroupArn
-          toFieldPath: spec.forProvider.accessLogSettings[0].destinationArn
+          - string:
+              fmt: '%s-api-stage'
+              type: Format
+            type: string
+          type: FromCompositeFieldPath
+        - fromFieldPath: status.apigwAccessLogsGroupArn
           policy:
             fromFieldPath: Required
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.atProvider.invokeUrl
+          toFieldPath: spec.forProvider.accessLogSettings[0].destinationArn
+          type: FromCompositeFieldPath
+        - fromFieldPath: status.atProvider.invokeUrl
           toFieldPath: status.apiBaseUrl
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.atProvider.arn
+          type: ToCompositeFieldPath
+        - fromFieldPath: status.atProvider.arn
           toFieldPath: status.apigwStageArn
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.atProvider.stageName
+          type: ToCompositeFieldPath
+        - fromFieldPath: status.atProvider.stageName
           toFieldPath: status.apigwStageName
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.tags
-          toFieldPath: spec.forProvider.tags
+          type: ToCompositeFieldPath
+        - fromFieldPath: spec.resourceConfig.tags
           policy:
-            mergeOptions:
-              keepMapValues: true
-
-    - name: api-access-logs-group
-      base:
-        apiVersion: cloudwatchlogs.aws.upbound.io/v1beta1
-        kind: Group
-        spec:
-          deletionPolicy: Delete
-          forProvider:
-            retentionInDays: 1
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.region
+            toFieldPath: MergeObjects
+          toFieldPath: spec.forProvider.tags
+          type: FromCompositeFieldPath
+      - base:
+          apiVersion: cloudwatchlogs.aws.upbound.io/v1beta1
+          kind: Group
+          spec:
+            deletionPolicy: Delete
+            forProvider:
+              retentionInDays: 1
+        name: api-access-logs-group
+        patches:
+        - patchSetName: common-fields
+          type: PatchSet
+        - fromFieldPath: spec.resourceConfig.region
           toFieldPath: spec.forProvider.region
-        - type: FromCompositeFieldPath
-          fromFieldPath: metadata.name
+          type: FromCompositeFieldPath
+        - fromFieldPath: metadata.name
           toFieldPath: metadata.name
           transforms:
-            - type: string
-              string:
-                fmt: "%s-api-access-logs"
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.logRetentionPeriod
+          - string:
+              fmt: '%s-api-access-logs'
+              type: Format
+            type: string
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.logRetentionPeriod
           toFieldPath: spec.forProvider.retentionInDays
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.atProvider.arn
+          type: FromCompositeFieldPath
+        - fromFieldPath: status.atProvider.arn
           toFieldPath: status.apigwAccessLogsGroupArn
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.tags
-          toFieldPath: spec.forProvider.tags
+          type: ToCompositeFieldPath
+        - fromFieldPath: spec.resourceConfig.tags
           policy:
-            mergeOptions:
-              keepMapValues: true
-
-    - name: apigw-logging-account
-      base:
-        apiVersion: apigateway.aws.upbound.io/v1beta1
-        kind: Account
-        spec:
-          deletionPolicy: Delete
-          forProvider:
-            cloudwatchRoleArnSelector: 
-              matchControllerRef: true
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.region
+            toFieldPath: MergeObjects
+          toFieldPath: spec.forProvider.tags
+          type: FromCompositeFieldPath
+      - base:
+          apiVersion: apigateway.aws.upbound.io/v1beta1
+          kind: Account
+          spec:
+            deletionPolicy: Delete
+            forProvider:
+              cloudwatchRoleArnSelector:
+                matchControllerRef: true
+        name: apigw-logging-account
+        patches:
+        - patchSetName: common-fields
+          type: PatchSet
+        - fromFieldPath: spec.resourceConfig.region
           toFieldPath: spec.forProvider.region
-        - type: FromCompositeFieldPath
-          fromFieldPath: metadata.name
+          type: FromCompositeFieldPath
+        - fromFieldPath: metadata.name
           toFieldPath: metadata.name
           transforms:
-            - type: string
-              string:
-                fmt: "%s-api-logging-account"
-
-    - name: api-method-settings
-      base:
-        apiVersion: apigateway.aws.upbound.io/v1beta1
-        kind: MethodSettings
-        spec:
-          deletionPolicy: Delete
-          forProvider:
-            restApiIdSelector:
-              matchControllerRef: true
-            stageNameSelector:
-              matchControllerRef: true
-            methodPath: "*/*"
-            settings:
-              - metricsEnabled: true
-                logging_level: "INFO"
-                dataTraceEnabled: true
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.region
+          - string:
+              fmt: '%s-api-logging-account'
+              type: Format
+            type: string
+          type: FromCompositeFieldPath
+      - base:
+          apiVersion: apigateway.aws.upbound.io/v1beta1
+          kind: MethodSettings
+          spec:
+            deletionPolicy: Delete
+            forProvider:
+              methodPath: '*/*'
+              restApiIdSelector:
+                matchControllerRef: true
+              settings:
+              - dataTraceEnabled: true
+                logging_level: INFO
+                metricsEnabled: true
+              stageNameSelector:
+                matchControllerRef: true
+        name: api-method-settings
+        patches:
+        - patchSetName: common-fields
+          type: PatchSet
+        - fromFieldPath: spec.resourceConfig.region
           toFieldPath: spec.forProvider.region
-        - type: FromCompositeFieldPath
-          fromFieldPath: metadata.name
+          type: FromCompositeFieldPath
+        - fromFieldPath: metadata.name
           toFieldPath: metadata.name
           transforms:
-            - type: string
-              string:
-                fmt: "%s-api-method-settings"
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.logLevel
+          - string:
+              fmt: '%s-api-method-settings'
+              type: Format
+            type: string
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.logLevel
           toFieldPath: spec.forProvider.settings[0].loggingLevel
+          type: FromCompositeFieldPath
+    step: patch-and-transform

--- a/compositions/upbound-aws-provider/aurora/aurora.yaml
+++ b/compositions/upbound-aws-provider/aurora/aurora.yaml
@@ -1,552 +1,562 @@
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
-  name: xauroras-postgresql.db.awsblueprint.io
   labels:
-    awsblueprints.io/provider: aws
     awsblueprints.io/environment: dev
+    awsblueprints.io/provider: aws
     cluster.awsblueprints.io/configuration: standard
     cluster.awsblueprints.io/type: postgresql
+  name: xauroras-postgresql.db.awsblueprint.io
 spec:
-  writeConnectionSecretsToNamespace: crossplane-system
   compositeTypeRef:
     apiVersion: db.awsblueprint.io/v1alpha1
     kind: XAurora
-  patchSets:
-    - name: common-fields
-      patches:
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.providerConfigName
+  mode: Pipeline
+  pipeline:
+  - functionRef:
+      name: function-patch-and-transform
+    input:
+      apiVersion: pt.fn.crossplane.io/v1beta1
+      kind: Resources
+      patchSets:
+      - name: common-fields
+        patches:
+        - fromFieldPath: spec.resourceConfig.providerConfigName
           toFieldPath: spec.providerConfigRef.name
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.deletionPolicy
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.resourceConfig.deletionPolicy
           toFieldPath: spec.deletionPolicy
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.region
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.resourceConfig.region
           toFieldPath: spec.forProvider.region
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.tags
-          toFieldPath: spec.forProvider.tags
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.resourceConfig.tags
           policy:
-            mergeOptions:
-              appendSlice: true
-  resources:
-    - name: aurora-cluster-subnetgroup
-      base:
-        apiVersion: rds.aws.upbound.io/v1beta1
-        kind: SubnetGroup
-        metadata:
-          name: aurora-cluster-sng
-        spec:
-          forProvider:
-            description: "aurora subnet group"
-            tags:
-              environment: dev
-              application: my-app
-              bu: test
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields
+            toFieldPath: ForceMergeObjectsAppendArrays
+          toFieldPath: spec.forProvider.tags
+          type: FromCompositeFieldPath
+      resources:
+      - base:
+          apiVersion: rds.aws.upbound.io/v1beta1
+          kind: SubnetGroup
+          metadata:
+            name: aurora-cluster-sng
+          spec:
+            forProvider:
+              description: aurora subnet group
+              tags:
+                application: my-app
+                bu: test
+                environment: dev
+        name: aurora-cluster-subnetgroup
+        patches:
+        - patchSetName: common-fields
+          type: PatchSet
         - fromFieldPath: spec.networkConfig.subnetIds
           toFieldPath: spec.forProvider.subnetIds
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.atProvider.arn
+          type: FromCompositeFieldPath
+        - fromFieldPath: status.atProvider.arn
           toFieldPath: status.subnetGroupArn
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.atProvider.id
-          toFieldPath: status.subnetGroupName 
-    - name: aurora-cluster-sg
-      base:
-        apiVersion: ec2.aws.upbound.io/v1beta1
-        kind: SecurityGroup
-        metadata:
-          name: aurora-cluster-sg
-          labels:
-            sg-selector: aurora-cluster-sg-label
-        spec:
-          forProvider:
-            description: "aurora cluster security group"
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields
+          type: ToCompositeFieldPath
+        - fromFieldPath: status.atProvider.id
+          toFieldPath: status.subnetGroupName
+          type: ToCompositeFieldPath
+      - base:
+          apiVersion: ec2.aws.upbound.io/v1beta1
+          kind: SecurityGroup
+          metadata:
+            labels:
+              sg-selector: aurora-cluster-sg-label
+            name: aurora-cluster-sg
+          spec:
+            forProvider:
+              description: aurora cluster security group
+        name: aurora-cluster-sg
+        patches:
+        - patchSetName: common-fields
+          type: PatchSet
         - fromFieldPath: spec.networkConfig.vpcId
           toFieldPath: spec.forProvider.vpcId
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.atProvider.id
+          type: FromCompositeFieldPath
+        - fromFieldPath: status.atProvider.id
           toFieldPath: status.securityGroupId
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.atProvider.arn
+          type: ToCompositeFieldPath
+        - fromFieldPath: status.atProvider.arn
           toFieldPath: status.securityGroupArn
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.atProvider.name
-          toFieldPath: status.securityGroupName  
-    - name: aurora-cluster-sg-self-rule
-      base:
-        apiVersion: ec2.aws.upbound.io/v1beta1
-        kind: SecurityGroupRule
-        metadata:
-          name: aurora-cluster-sg-self-rule
-        spec:
-          forProvider:
-            protocol: tcp
-            self: true
-            type: ingress
-            securityGroupIdSelector:
-              matchLabels:
-                sg-selector: aurora-cluster-sg-label
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.networkConfig.allowedPort
+          type: ToCompositeFieldPath
+        - fromFieldPath: status.atProvider.name
+          toFieldPath: status.securityGroupName
+          type: ToCompositeFieldPath
+      - base:
+          apiVersion: ec2.aws.upbound.io/v1beta1
+          kind: SecurityGroupRule
+          metadata:
+            name: aurora-cluster-sg-self-rule
+          spec:
+            forProvider:
+              protocol: tcp
+              securityGroupIdSelector:
+                matchLabels:
+                  sg-selector: aurora-cluster-sg-label
+              self: true
+              type: ingress
+        name: aurora-cluster-sg-self-rule
+        patches:
+        - patchSetName: common-fields
+          type: PatchSet
+        - fromFieldPath: spec.networkConfig.allowedPort
           toFieldPath: spec.forProvider.fromPort
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.networkConfig.allowedPort
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.networkConfig.allowedPort
           toFieldPath: spec.forProvider.toPort
-        - type: FromCompositeFieldPath
-          fromFieldPath: status.securityGroupId
+          type: FromCompositeFieldPath
+        - fromFieldPath: status.securityGroupId
           toFieldPath: spec.forProvider.securityGroupId
-    - name: aurora-cluster-sg-app-rule
-      base:
-        apiVersion: ec2.aws.upbound.io/v1beta1
-        kind: SecurityGroupRule
-        metadata:
-          name: aurora-cluster-sg-app-rule
-        spec:
-          forProvider:
-            protocol: tcp
-            type: ingress
-            securityGroupIdSelector:
-              matchLabels:
-                sg-selector: aurora-cluster-sg-label
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.networkConfig.allowedPort
+          type: FromCompositeFieldPath
+      - base:
+          apiVersion: ec2.aws.upbound.io/v1beta1
+          kind: SecurityGroupRule
+          metadata:
+            name: aurora-cluster-sg-app-rule
+          spec:
+            forProvider:
+              protocol: tcp
+              securityGroupIdSelector:
+                matchLabels:
+                  sg-selector: aurora-cluster-sg-label
+              type: ingress
+        name: aurora-cluster-sg-app-rule
+        patches:
+        - patchSetName: common-fields
+          type: PatchSet
+        - fromFieldPath: spec.networkConfig.allowedPort
           toFieldPath: spec.forProvider.fromPort
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.networkConfig.allowedPort
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.networkConfig.allowedPort
           toFieldPath: spec.forProvider.toPort
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.networkConfig.allowedCidrBlocks
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.networkConfig.allowedCidrBlocks
           toFieldPath: spec.forProvider.cidrBlocks
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.networkConfig.allowedSecurityGroupId
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.networkConfig.allowedSecurityGroupId
           toFieldPath: spec.forProvider.sourceSecurityGroupId
-        - type: FromCompositeFieldPath
-          fromFieldPath: status.securityGroupId
+          type: FromCompositeFieldPath
+        - fromFieldPath: status.securityGroupId
           toFieldPath: spec.forProvider.securityGroupId
-    - name: aurora-cluster-sg-egress-rule
-      base:
-        apiVersion: ec2.aws.upbound.io/v1beta1
-        kind: SecurityGroupRule
-        metadata:
-          name: aurora-cluster-sg-egress-rule
-        spec:
-          forProvider:
-            protocol: tcp
-            type: egress
-            securityGroupIdSelector:
-              matchLabels:
-                sg-selector: aurora-cluster-sg-label
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.networkConfig.allowedPort
+          type: FromCompositeFieldPath
+      - base:
+          apiVersion: ec2.aws.upbound.io/v1beta1
+          kind: SecurityGroupRule
+          metadata:
+            name: aurora-cluster-sg-egress-rule
+          spec:
+            forProvider:
+              protocol: tcp
+              securityGroupIdSelector:
+                matchLabels:
+                  sg-selector: aurora-cluster-sg-label
+              type: egress
+        name: aurora-cluster-sg-egress-rule
+        patches:
+        - patchSetName: common-fields
+          type: PatchSet
+        - fromFieldPath: spec.networkConfig.allowedPort
           toFieldPath: spec.forProvider.fromPort
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.networkConfig.allowedPort
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.networkConfig.allowedPort
           toFieldPath: spec.forProvider.toPort
-        - type: FromCompositeFieldPath
-          fromFieldPath: status.securityGroupId
+          type: FromCompositeFieldPath
+        - fromFieldPath: status.securityGroupId
           toFieldPath: spec.forProvider.securityGroupId
-        - type: FromCompositeFieldPath
-          fromFieldPath: status.securityGroupId
+          type: FromCompositeFieldPath
+        - fromFieldPath: status.securityGroupId
           toFieldPath: spec.forProvider.sourceSecurityGroupId
-    - name: rds-cluster-para-group
-      base:
-        apiVersion: rds.aws.upbound.io/v1beta1
-        kind: ClusterParameterGroup
-        metadata:
-          name: aurora-cluster-parameter-group
-        spec:
-          forProvider:
-            description: Aurora cluster parameter group
-            family: aurora-postgresql15
-            parameter:
+          type: FromCompositeFieldPath
+      - base:
+          apiVersion: rds.aws.upbound.io/v1beta1
+          kind: ClusterParameterGroup
+          metadata:
+            name: aurora-cluster-parameter-group
+          spec:
+            forProvider:
+              description: Aurora cluster parameter group
+              family: aurora-postgresql15
+              parameter:
               - name: rds.force_ssl
                 value: "1"
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.clusterConfig.parameterGroupFamily
+        name: rds-cluster-para-group
+        patches:
+        - patchSetName: common-fields
+          type: PatchSet
+        - fromFieldPath: spec.clusterConfig.parameterGroupFamily
           toFieldPath: spec.forProvider.family
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.atProvider.arn
+          type: FromCompositeFieldPath
+        - fromFieldPath: status.atProvider.arn
           toFieldPath: status.clusterParameterGroupArn
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.atProvider.id
+          type: ToCompositeFieldPath
+        - fromFieldPath: status.atProvider.id
           toFieldPath: status.clusterParameterGroupName
-    - name: aurora-cluster 
-      connectionDetails:
-      - type: FromFieldPath
-        name: clusterUsername
-        fromFieldPath: status.atProvider.masterUsername
-      base:
-        apiVersion: rds.aws.upbound.io/v1beta1
-        kind: Cluster
-        spec:
-          forProvider:
-            writeConnectionSecretToRef:
-              namespace: crossplane-system
-            engine: aurora-postgresql
-            engineVersion: "15.2"
-            manageMasterUserPassword: true
-            masterUsername: adminuser
-            skipFinalSnapshot: true
-            storageEncrypted: true
-            enableHttpEndpoint: false
-            copyTagsToSnapshot: true
-            databaseName: auroradb
-            storageType: "aurora-iopt1"
-            finalSnapshotIdentifier: "aurora-cluster-final-snapshot"
-            backupRetentionPeriod: 7
-            preferredBackupWindow: 02:00-03:00
-            preferredMaintenanceWindow: sun:04:00-sun:05:00
-            dbClusterParameterGroupName: default.aurora-postgresql15
-            vpcSecurityGroupIDs: [] 
-            vpcSecurityGroupIDSelector:
-              matchControllerRef: true
-            dbSubnetGroupNameSelector:
-              matchControllerRef: true
-            tags:
-              environment: dev
-              application: my-app
-              bu: bu-name
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.clusterConfig.databaseName
+          type: ToCompositeFieldPath
+      - base:
+          apiVersion: rds.aws.upbound.io/v1beta1
+          kind: Cluster
+          spec:
+            forProvider:
+              backupRetentionPeriod: 7
+              copyTagsToSnapshot: true
+              databaseName: auroradb
+              dbClusterParameterGroupName: default.aurora-postgresql15
+              dbSubnetGroupNameSelector:
+                matchControllerRef: true
+              enableHttpEndpoint: false
+              engine: aurora-postgresql
+              engineVersion: "15.2"
+              finalSnapshotIdentifier: aurora-cluster-final-snapshot
+              manageMasterUserPassword: true
+              masterUsername: adminuser
+              preferredBackupWindow: 02:00-03:00
+              preferredMaintenanceWindow: sun:04:00-sun:05:00
+              skipFinalSnapshot: true
+              storageEncrypted: true
+              storageType: aurora-iopt1
+              tags:
+                application: my-app
+                bu: bu-name
+                environment: dev
+              vpcSecurityGroupIDSelector:
+                matchControllerRef: true
+              vpcSecurityGroupIDs: []
+              writeConnectionSecretToRef:
+                namespace: crossplane-system
+        connectionDetails:
+        - fromFieldPath: status.atProvider.masterUsername
+          name: clusterUsername
+          type: FromFieldPath
+        name: aurora-cluster
+        patches:
+        - patchSetName: common-fields
+          type: PatchSet
+        - fromFieldPath: spec.clusterConfig.databaseName
           toFieldPath: spec.forProvider.databaseName
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.clusterConfig.engine
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.clusterConfig.engine
           toFieldPath: spec.forProvider.engine
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.clusterConfig.engineVersion
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.clusterConfig.engineVersion
           toFieldPath: spec.forProvider.engineVersion
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.clusterConfig.masterUsername
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.clusterConfig.masterUsername
           toFieldPath: spec.forProvider.masterUsername
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.clusterConfig.skipFinalSnapshot
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.clusterConfig.skipFinalSnapshot
           toFieldPath: spec.forProvider.skipFinalSnapshot
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.clusterConfig.storageType
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.clusterConfig.storageType
           toFieldPath: spec.forProvider.storageType
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.clusterConfig.allocatedStorage
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.clusterConfig.allocatedStorage
           toFieldPath: spec.forProvider.allocatedStorage
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.clusterConfig.availabilityZones
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.clusterConfig.availabilityZones
           toFieldPath: spec.forProvider.availabilityZones
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.clusterConfig.backupRetentionPeriod
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.clusterConfig.backupRetentionPeriod
           toFieldPath: spec.forProvider.backupRetentionPeriod
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.clusterConfig.enabledCloudwatchLogsExports
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.clusterConfig.enabledCloudwatchLogsExports
           toFieldPath: spec.forProvider.enabledCloudwatchLogsExports
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.clusterConfig.preferredBackupWindow
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.clusterConfig.preferredBackupWindow
           toFieldPath: spec.forProvider.preferredBackupWindow
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.clusterConfig.preferredMaintenanceWindow
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.clusterConfig.preferredMaintenanceWindow
           toFieldPath: spec.forProvider.preferredMaintenanceWindow
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.clusterConfig.applyImmediately
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.clusterConfig.applyImmediately
           toFieldPath: spec.forProvider.applyImmediately
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.clusterConfig.snapshotIdentifier
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.clusterConfig.snapshotIdentifier
           toFieldPath: spec.forProvider.snapshotIdentifier
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.clusterConfig.finalSnapshotIdentifier
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.clusterConfig.finalSnapshotIdentifier
           toFieldPath: spec.forProvider.finalSnapshotIdentifier
-        - type: FromCompositeFieldPath
-          fromFieldPath: status.clusterParameterGroupName
+          type: FromCompositeFieldPath
+        - fromFieldPath: status.clusterParameterGroupName
           toFieldPath: spec.forProvider.dbClusterParameterGroupName
-        - type: FromCompositeFieldPath
-          fromFieldPath: status.securityGroupId
+          type: FromCompositeFieldPath
+        - fromFieldPath: status.securityGroupId
           toFieldPath: spec.forProvider.vpcSecurityGroupIds[0]
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.atProvider.id
+          type: FromCompositeFieldPath
+        - fromFieldPath: status.atProvider.id
           toFieldPath: status.clusterIdentifier
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.atProvider.arn
+          type: ToCompositeFieldPath
+        - fromFieldPath: status.atProvider.arn
           toFieldPath: status.clusterArn
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.atProvider.readerEndpoint
+          type: ToCompositeFieldPath
+        - fromFieldPath: status.atProvider.readerEndpoint
           toFieldPath: status.clusterReaderEndpoint
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.atProvider.endpoint
+          type: ToCompositeFieldPath
+        - fromFieldPath: status.atProvider.endpoint
           toFieldPath: status.clusterEndpoint
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.atProvider.masterUserSecret[0].secretArn
+          type: ToCompositeFieldPath
+        - fromFieldPath: status.atProvider.masterUserSecret[0].secretArn
           toFieldPath: status.clusterMasterSecretArn
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.atProvider.masterUsername
+          type: ToCompositeFieldPath
+        - fromFieldPath: status.atProvider.masterUsername
           toFieldPath: status.clusterUsername
-    - name: aurora-cluster-instance-01
-      base:
-        apiVersion: rds.aws.upbound.io/v1beta1
-        kind: ClusterInstance
-        spec:
-          forProvider:
-            promotionTier: 0
-            engine: aurora-postgresql
-            engineVersion: "15.2"
-            instanceClass: db.r6g.large
-            publiclyAccessible: false
-            autoMinorVersionUpgrade: true
-            copyTagsToSnapshot: true
-            performanceInsightsEnabled: true
-            dbSubnetGroupNameSelector:
-              matchControllerRef: true
-            clusterIdentifierSelector:
-              matchControllerRef: true
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.clusterConfig.engine
+          type: ToCompositeFieldPath
+      - base:
+          apiVersion: rds.aws.upbound.io/v1beta1
+          kind: ClusterInstance
+          spec:
+            forProvider:
+              autoMinorVersionUpgrade: true
+              clusterIdentifierSelector:
+                matchControllerRef: true
+              copyTagsToSnapshot: true
+              dbSubnetGroupNameSelector:
+                matchControllerRef: true
+              engine: aurora-postgresql
+              engineVersion: "15.2"
+              instanceClass: db.r6g.large
+              performanceInsightsEnabled: true
+              promotionTier: 0
+              publiclyAccessible: false
+        name: aurora-cluster-instance-01
+        patches:
+        - patchSetName: common-fields
+          type: PatchSet
+        - fromFieldPath: spec.clusterConfig.engine
           toFieldPath: spec.forProvider.engine
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.clusterConfig.engineVersion
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.clusterConfig.engineVersion
           toFieldPath: spec.forProvider.engineVersion
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.clusterConfig.clusterInstanceClass
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.clusterConfig.clusterInstanceClass
           toFieldPath: spec.forProvider.instanceClass
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.clusterConfig.performanceInsightsEnabled
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.clusterConfig.performanceInsightsEnabled
           toFieldPath: spec.forProvider.performanceInsightsEnabled
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.clusterConfig.monitoringRoleArn
-          toFieldPath: spec.forProvider.monitoringRoleArn  
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.clusterConfig.monitoringInterval
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.clusterConfig.monitoringRoleArn
+          toFieldPath: spec.forProvider.monitoringRoleArn
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.clusterConfig.monitoringInterval
           toFieldPath: spec.forProvider.monitoringInterval
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.clusterConfig.applyImmediately
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.clusterConfig.applyImmediately
           toFieldPath: spec.forProvider.applyImmediately
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.clusterConfig.performanceInsightsRetentionPeriod
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.clusterConfig.performanceInsightsRetentionPeriod
           toFieldPath: spec.forProvider.performanceInsightsRetentionPeriod
-        - type: FromCompositeFieldPath
-          fromFieldPath: status.clusterIdentifier
+          type: FromCompositeFieldPath
+        - fromFieldPath: status.clusterIdentifier
           toFieldPath: spec.forProvider.clusterIdentifier
-    - name: aurora-cluster-instance-02
-      base:
-        apiVersion: rds.aws.upbound.io/v1beta1
-        kind: ClusterInstance
-        spec:
-          forProvider:
-            promotionTier: 1
-            engine: aurora-postgresql
-            engineVersion: "15.2"
-            instanceClass: db.r6g.large
-            publiclyAccessible: false
-            autoMinorVersionUpgrade: true
-            copyTagsToSnapshot: true
-            performanceInsightsEnabled: true
-            dbSubnetGroupNameSelector:
-              matchControllerRef: true
-            clusterIdentifierSelector:
-              matchControllerRef: true
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.clusterConfig.engine
+          type: FromCompositeFieldPath
+      - base:
+          apiVersion: rds.aws.upbound.io/v1beta1
+          kind: ClusterInstance
+          spec:
+            forProvider:
+              autoMinorVersionUpgrade: true
+              clusterIdentifierSelector:
+                matchControllerRef: true
+              copyTagsToSnapshot: true
+              dbSubnetGroupNameSelector:
+                matchControllerRef: true
+              engine: aurora-postgresql
+              engineVersion: "15.2"
+              instanceClass: db.r6g.large
+              performanceInsightsEnabled: true
+              promotionTier: 1
+              publiclyAccessible: false
+        name: aurora-cluster-instance-02
+        patches:
+        - patchSetName: common-fields
+          type: PatchSet
+        - fromFieldPath: spec.clusterConfig.engine
           toFieldPath: spec.forProvider.engine
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.clusterConfig.engineVersion
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.clusterConfig.engineVersion
           toFieldPath: spec.forProvider.engineVersion
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.clusterConfig.clusterInstanceClass
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.clusterConfig.clusterInstanceClass
           toFieldPath: spec.forProvider.instanceClass
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.clusterConfig.performanceInsightsEnabled
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.clusterConfig.performanceInsightsEnabled
           toFieldPath: spec.forProvider.performanceInsightsEnabled
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.clusterConfig.monitoringRoleArn
-          toFieldPath: spec.forProvider.monitoringRoleArn  
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.clusterConfig.monitoringInterval
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.clusterConfig.monitoringRoleArn
+          toFieldPath: spec.forProvider.monitoringRoleArn
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.clusterConfig.monitoringInterval
           toFieldPath: spec.forProvider.monitoringInterval
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.clusterConfig.applyImmediately
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.clusterConfig.applyImmediately
           toFieldPath: spec.forProvider.applyImmediately
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.clusterConfig.performanceInsightsRetentionPeriod
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.clusterConfig.performanceInsightsRetentionPeriod
           toFieldPath: spec.forProvider.performanceInsightsRetentionPeriod
-        - type: FromCompositeFieldPath
-          fromFieldPath: status.clusterIdentifier
+          type: FromCompositeFieldPath
+        - fromFieldPath: status.clusterIdentifier
           toFieldPath: spec.forProvider.clusterIdentifier
-    - name: aurora-cluster-instance-03
-      base:
-        apiVersion: rds.aws.upbound.io/v1beta1
-        kind: ClusterInstance
-        spec:
-          forProvider:
-            promotionTier: 2
-            engine: aurora-postgresql
-            engineVersion: "15.2"
-            instanceClass: db.r6g.large
-            publiclyAccessible: false
-            autoMinorVersionUpgrade: true
-            copyTagsToSnapshot: true
-            performanceInsightsEnabled: true
-            dbSubnetGroupNameSelector:
-              matchControllerRef: true
-            clusterIdentifierSelector:
-              matchControllerRef: true
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.clusterConfig.engine
+          type: FromCompositeFieldPath
+      - base:
+          apiVersion: rds.aws.upbound.io/v1beta1
+          kind: ClusterInstance
+          spec:
+            forProvider:
+              autoMinorVersionUpgrade: true
+              clusterIdentifierSelector:
+                matchControllerRef: true
+              copyTagsToSnapshot: true
+              dbSubnetGroupNameSelector:
+                matchControllerRef: true
+              engine: aurora-postgresql
+              engineVersion: "15.2"
+              instanceClass: db.r6g.large
+              performanceInsightsEnabled: true
+              promotionTier: 2
+              publiclyAccessible: false
+        name: aurora-cluster-instance-03
+        patches:
+        - patchSetName: common-fields
+          type: PatchSet
+        - fromFieldPath: spec.clusterConfig.engine
           toFieldPath: spec.forProvider.engine
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.clusterConfig.engineVersion
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.clusterConfig.engineVersion
           toFieldPath: spec.forProvider.engineVersion
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.clusterConfig.clusterInstanceClass
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.clusterConfig.clusterInstanceClass
           toFieldPath: spec.forProvider.instanceClass
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.clusterConfig.performanceInsightsEnabled
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.clusterConfig.performanceInsightsEnabled
           toFieldPath: spec.forProvider.performanceInsightsEnabled
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.clusterConfig.monitoringRoleArn
-          toFieldPath: spec.forProvider.monitoringRoleArn  
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.clusterConfig.monitoringInterval
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.clusterConfig.monitoringRoleArn
+          toFieldPath: spec.forProvider.monitoringRoleArn
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.clusterConfig.monitoringInterval
           toFieldPath: spec.forProvider.monitoringInterval
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.clusterConfig.applyImmediately
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.clusterConfig.applyImmediately
           toFieldPath: spec.forProvider.applyImmediately
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.clusterConfig.performanceInsightsRetentionPeriod
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.clusterConfig.performanceInsightsRetentionPeriod
           toFieldPath: spec.forProvider.performanceInsightsRetentionPeriod
-        - type: FromCompositeFieldPath
-          fromFieldPath: status.clusterIdentifier
+          type: FromCompositeFieldPath
+        - fromFieldPath: status.clusterIdentifier
           toFieldPath: spec.forProvider.clusterIdentifier
-    - name: aurora-cluster-proxy
-      connectionDetails:
-        - type: FromFieldPath
+          type: FromCompositeFieldPath
+      - base:
+          apiVersion: rds.aws.upbound.io/v1beta1
+          kind: Proxy
+          metadata:
+            name: aurora-proxy
+          spec:
+            forProvider:
+              auth:
+              - authScheme: SECRETS
+                description: auth for aurora proxy
+                iamAuth: REQUIRED
+              debugLogging: true
+              engineFamily: POSTGRESQL
+              idleClientTimeout: 1800
+              requireTls: true
+              tags:
+                application: my-app
+                bu: test
+                environment: dev
+              vpcSecurityGroupIDSelector:
+                matchControllerRef: true
+              vpcSecurityGroupIds: []
+              writeConnectionSecretToRef:
+                namespace: crossplane-system
+        connectionDetails:
+        - fromFieldPath: status.atProvider.endpoint
           name: proxyEndpoint
-          fromFieldPath: status.atProvider.endpoint
-      base:
-        apiVersion: rds.aws.upbound.io/v1beta1
-        kind: Proxy
-        metadata:
-          name: aurora-proxy
-        spec:
-          forProvider:
-            writeConnectionSecretToRef:
-              namespace: crossplane-system
-            auth:
-            - authScheme: SECRETS
-              description: "auth for aurora proxy"
-              iamAuth: REQUIRED
-            engineFamily: POSTGRESQL
-            requireTls: true
-            debugLogging: true
-            idleClientTimeout: 1800
-            vpcSecurityGroupIds: []
-            vpcSecurityGroupIDSelector:
-              matchControllerRef: true
-            tags:
-              environment: dev
-              application: my-app
-              bu: test
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.proxyConfig.debugLogging
+          type: FromFieldPath
+        name: aurora-cluster-proxy
+        patches:
+        - patchSetName: common-fields
+          type: PatchSet
+        - fromFieldPath: spec.proxyConfig.debugLogging
           toFieldPath: spec.forProvider.debugLogging
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.proxyConfig.idleClientTimeout
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.proxyConfig.idleClientTimeout
           toFieldPath: spec.forProvider.idleClientTimeout
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.proxyConfig.proxyRoleArn
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.proxyConfig.proxyRoleArn
           toFieldPath: spec.forProvider.roleArn
+          type: FromCompositeFieldPath
         - fromFieldPath: spec.networkConfig.subnetIds
           toFieldPath: spec.forProvider.vpcSubnetIds
-        - type: FromCompositeFieldPath
-          fromFieldPath: status.clusterMasterSecretArn
+          type: FromCompositeFieldPath
+        - fromFieldPath: status.clusterMasterSecretArn
           toFieldPath: spec.forProvider.auth[0].secretArn
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.proxyConfig.iamAuth
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.proxyConfig.iamAuth
           toFieldPath: spec.forProvider.auth[0].iamAuth
-        - type: FromCompositeFieldPath
-          fromFieldPath: status.securityGroupId
-          toFieldPath: spec.forProvider.vpcSecurityGroupIds[0]  
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.atProvider.arn
+          type: FromCompositeFieldPath
+        - fromFieldPath: status.securityGroupId
+          toFieldPath: spec.forProvider.vpcSecurityGroupIds[0]
+          type: FromCompositeFieldPath
+        - fromFieldPath: status.atProvider.arn
           toFieldPath: status.proxyArn
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.atProvider.endpoint
+          type: ToCompositeFieldPath
+        - fromFieldPath: status.atProvider.endpoint
           toFieldPath: status.proxyEndpoint
-    - name: aurora-cluster-proxy-default-tg
-      base:
-        apiVersion: rds.aws.upbound.io/v1beta1
-        kind: ProxyDefaultTargetGroup
-        metadata:
-          name: aurora-proxy-default-tg
-        spec:
-          forProvider:
-            connectionPoolConfig:
-            - connectionBorrowTimeout: 10
-              maxConnectionsPercent: 50
-              maxIdleConnectionsPercent: 50
-            dbProxyNameSelector:
-              matchControllerRef: true
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.proxyConfig.connectionBorrowTimeout
+          type: ToCompositeFieldPath
+      - base:
+          apiVersion: rds.aws.upbound.io/v1beta1
+          kind: ProxyDefaultTargetGroup
+          metadata:
+            name: aurora-proxy-default-tg
+          spec:
+            forProvider:
+              connectionPoolConfig:
+              - connectionBorrowTimeout: 10
+                maxConnectionsPercent: 50
+                maxIdleConnectionsPercent: 50
+              dbProxyNameSelector:
+                matchControllerRef: true
+        name: aurora-cluster-proxy-default-tg
+        patches:
+        - patchSetName: common-fields
+          type: PatchSet
+        - fromFieldPath: spec.proxyConfig.connectionBorrowTimeout
           toFieldPath: spec.forProvider.connectionPoolConfig[0].connectionBorrowTimeout
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.proxyConfig.maxConnectionsPercent
-          toFieldPath: spec.forProvider.connectionPoolConfig[0].maxConnectionsPercent  
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.proxyConfig.maxIdleConnectionsPercent
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.proxyConfig.maxConnectionsPercent
+          toFieldPath: spec.forProvider.connectionPoolConfig[0].maxConnectionsPercent
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.proxyConfig.maxIdleConnectionsPercent
           toFieldPath: spec.forProvider.connectionPoolConfig[0].maxIdleConnectionsPercent
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.atProvider.name
-          toFieldPath: status.defaultProxyTgName 
-    - name: aurora-cluster-proxy-target  
-      base:
-        apiVersion: rds.aws.upbound.io/v1beta1
-        kind: ProxyTarget
-        metadata:
-          name: aurora-proxy-target
-        spec:
-          forProvider:
-            dbClusterIdentifier: proxy-db-sg
-            dbProxyNameSelector:
-              matchControllerRef: true
-            targetGroupName: default   
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields
-        - type: FromCompositeFieldPath
-          fromFieldPath: status.defaultProxyTgName
+          type: FromCompositeFieldPath
+        - fromFieldPath: status.atProvider.name
+          toFieldPath: status.defaultProxyTgName
+          type: ToCompositeFieldPath
+      - base:
+          apiVersion: rds.aws.upbound.io/v1beta1
+          kind: ProxyTarget
+          metadata:
+            name: aurora-proxy-target
+          spec:
+            forProvider:
+              dbClusterIdentifier: proxy-db-sg
+              dbProxyNameSelector:
+                matchControllerRef: true
+              targetGroupName: default
+        name: aurora-cluster-proxy-target
+        patches:
+        - patchSetName: common-fields
+          type: PatchSet
+        - fromFieldPath: status.defaultProxyTgName
           toFieldPath: spec.forProvider.targetGroupName
-        - type: FromCompositeFieldPath
-          fromFieldPath: status.clusterIdentifier
+          type: FromCompositeFieldPath
+        - fromFieldPath: status.clusterIdentifier
           toFieldPath: spec.forProvider.dbClusterIdentifier
+          type: FromCompositeFieldPath
+    step: patch-and-transform
+  writeConnectionSecretsToNamespace: crossplane-system

--- a/compositions/upbound-aws-provider/aurora/aurora.yaml
+++ b/compositions/upbound-aws-provider/aurora/aurora.yaml
@@ -226,8 +226,8 @@ spec:
               vpcSecurityGroupIDSelector:
                 matchControllerRef: true
               vpcSecurityGroupIDs: []
-              writeConnectionSecretToRef:
-                namespace: crossplane-system
+            writeConnectionSecretToRef:
+              namespace: crossplane-system
         connectionDetails:
         - fromFieldPath: status.atProvider.masterUsername
           name: clusterUsername
@@ -471,8 +471,8 @@ spec:
               vpcSecurityGroupIDSelector:
                 matchControllerRef: true
               vpcSecurityGroupIds: []
-              writeConnectionSecretToRef:
-                namespace: crossplane-system
+            writeConnectionSecretToRef:
+              namespace: crossplane-system
         connectionDetails:
         - fromFieldPath: status.atProvider.endpoint
           name: proxyEndpoint

--- a/compositions/upbound-aws-provider/cloudwatch-logs/subscriptionfilter.yaml
+++ b/compositions/upbound-aws-provider/cloudwatch-logs/subscriptionfilter.yaml
@@ -1,68 +1,75 @@
-
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
-  name: subscriptionfilter.upbound.awsblueprints.io
   annotations:
     argocd.argoproj.io/sync-wave: "-10"
   labels:
-    awsblueprints.io/provider: aws
     awsblueprints.io/environment: dev
-    cloudwatch.awsblueprints.io/service: cloudwatch-logs
+    awsblueprints.io/provider: aws
     cloudwatch.awsblueprints.io/logs: subscriptionfilter
+    cloudwatch.awsblueprints.io/service: cloudwatch-logs
+  name: subscriptionfilter.upbound.awsblueprints.io
 spec:
   compositeTypeRef:
     apiVersion: awsblueprints.io/v1alpha1
     kind: XSubscriptionFilter
-  patchSets:
-    - name: common-fields
-      patches:
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.deletionPolicy
+  mode: Pipeline
+  pipeline:
+  - functionRef:
+      name: function-patch-and-transform
+    input:
+      apiVersion: pt.fn.crossplane.io/v1beta1
+      kind: Resources
+      patchSets:
+      - name: common-fields
+        patches:
+        - fromFieldPath: spec.resourceConfig.deletionPolicy
           toFieldPath: spec.deletionPolicy
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.region
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.resourceConfig.region
           toFieldPath: spec.forProvider.region
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.tags
-          toFieldPath: spec.forProvider.tags
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.resourceConfig.tags
           policy:
-            mergeOptions:
-              keepMapValues: true
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.name
+            toFieldPath: MergeObjects
+          toFieldPath: spec.forProvider.tags
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.resourceConfig.name
           toFieldPath: metadata.annotations[crossplane.io/external-name]
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.providerConfigName
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.resourceConfig.providerConfigName
           toFieldPath: spec.providerConfigRef.name
-        - type: FromCompositeFieldPath
-          fromFieldPath: metadata.name
+          type: FromCompositeFieldPath
+        - fromFieldPath: metadata.name
           toFieldPath: metadata.name
           transforms:
-            - type: string
-              string:
-                fmt: "subscriptionfilter-%s"
-  resources:
-    - name: subscriptionfilter
-      base:
-        apiVersion: cloudwatchlogs.aws.upbound.io/v1beta1
-        kind: SubscriptionFilter
-        spec:
-          forProvider: {}
-      patches:
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.forProvider
+          - string:
+              fmt: subscriptionfilter-%s
+              type: Format
+            type: string
+          type: FromCompositeFieldPath
+      resources:
+      - base:
+          apiVersion: cloudwatchlogs.aws.upbound.io/v1beta1
+          kind: SubscriptionFilter
+          spec:
+            forProvider: {}
+        name: subscriptionfilter
+        patches:
+        - fromFieldPath: spec.forProvider
           toFieldPath: spec.forProvider
-        - type: PatchSet
-          patchSetName: common-fields
-        - type: FromCompositeFieldPath
-          fromFieldPath: metadata.name
+          type: FromCompositeFieldPath
+        - patchSetName: common-fields
+          type: PatchSet
+        - fromFieldPath: metadata.name
           toFieldPath: spec.forProvider.name
           transforms:
-            - type: string
-              string:
-                fmt: "subscriptionfilter-%s"
-
+          - string:
+              fmt: subscriptionfilter-%s
+              type: Format
+            type: string
+          type: FromCompositeFieldPath
+    step: patch-and-transform

--- a/compositions/upbound-aws-provider/dynamo-irsa/dynamo-irsa.yaml
+++ b/compositions/upbound-aws-provider/dynamo-irsa/dynamo-irsa.yaml
@@ -4,74 +4,82 @@
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
-  name: xdynamoirsa.awsblueprints.io
   annotations:
     argocd.argoproj.io/sync-wave: "-10"
   labels:
-    awsblueprints.io/provider: aws
     awsblueprints.io/environment: dev
+    awsblueprints.io/provider: aws
+  name: xdynamoirsa.awsblueprints.io
 spec:
-  writeConnectionSecretsToNamespace: crossplane-system
   compositeTypeRef:
     apiVersion: awsblueprints.io/v1alpha1
     kind: XDynamoIRSA
-  patchSets:
-    - name: common-fields-composition
-      patches:
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig
+  mode: Pipeline
+  pipeline:
+  - functionRef:
+      name: function-patch-and-transform
+    input:
+      apiVersion: pt.fn.crossplane.io/v1beta1
+      kind: Resources
+      patchSets:
+      - name: common-fields-composition
+        patches:
+        - fromFieldPath: spec.resourceConfig
           toFieldPath: spec.resourceConfig
-  resources:
-    - name: dynamodbtable
-      connectionDetails:
-        - type: FromFieldPath
+          type: FromCompositeFieldPath
+      resources:
+      - base:
+          apiVersion: awsblueprints.io/v1alpha1
+          kind: XDynamoDBTable
+        connectionDetails:
+        - fromFieldPath: status.tableName
           name: tableName
-          fromFieldPath: status.tableName
-      base:
-        apiVersion: awsblueprints.io/v1alpha1
-        kind: XDynamoDBTable
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields-composition
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.dynamoConfig
+          type: FromFieldPath
+        name: dynamodbtable
+        patches:
+        - patchSetName: common-fields-composition
+          type: PatchSet
+        - fromFieldPath: spec.dynamoConfig
           toFieldPath: spec.dynamoConfig
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.tableName
+          type: FromCompositeFieldPath
+        - fromFieldPath: status.tableName
           toFieldPath: status.tableName
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.tableArn
+          type: ToCompositeFieldPath
+        - fromFieldPath: status.tableArn
           toFieldPath: status.tableArn
-    - name: irsa
-      base:
-        apiVersion: awsblueprints.io/v1alpha1
-        kind: XIRSA
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields-composition
-        - type: FromCompositeFieldPath
-          fromFieldPath: metadata.labels[crossplane.io/claim-name]
+          type: ToCompositeFieldPath
+      - base:
+          apiVersion: awsblueprints.io/v1alpha1
+          kind: XIRSA
+        name: irsa
+        patches:
+        - patchSetName: common-fields-composition
+          type: PatchSet
+        - fromFieldPath: metadata.labels[crossplane.io/claim-name]
           toFieldPath: spec.serviceAccountName
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.roleName
+          type: FromCompositeFieldPath
+        - fromFieldPath: status.roleName
           toFieldPath: status.roleName
-    - name: irsa-dynamo-policy
-      base:
-        apiVersion: awsblueprints.io/v1alpha1
-        kind: IAMPolicy
-        spec:
-          compositionSelector:
-            matchLabels:
-              awsblueprints.io/provider: aws
-              awsblueprints.io/environment: dev
-              iam.awsblueprints.io/policy-type: write
-              iam.awsblueprints.io/service: dynamodb
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields-composition
-        - type: FromCompositeFieldPath
-          fromFieldPath: status.roleName
+          type: ToCompositeFieldPath
+      - base:
+          apiVersion: awsblueprints.io/v1alpha1
+          kind: IAMPolicy
+          spec:
+            compositionSelector:
+              matchLabels:
+                awsblueprints.io/environment: dev
+                awsblueprints.io/provider: aws
+                iam.awsblueprints.io/policy-type: write
+                iam.awsblueprints.io/service: dynamodb
+        name: irsa-dynamo-policy
+        patches:
+        - patchSetName: common-fields-composition
+          type: PatchSet
+        - fromFieldPath: status.roleName
           toFieldPath: spec.roleName
-        - type: FromCompositeFieldPath
-          fromFieldPath: status.tableArn
+          type: FromCompositeFieldPath
+        - fromFieldPath: status.tableArn
           toFieldPath: spec.resourceArn
+          type: FromCompositeFieldPath
+    step: patch-and-transform
+  writeConnectionSecretsToNamespace: crossplane-system

--- a/compositions/upbound-aws-provider/dynamodb/table.yaml
+++ b/compositions/upbound-aws-provider/dynamodb/table.yaml
@@ -4,86 +4,89 @@
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
-  name: table.dynamodb.awsblueprints.io
   labels:
-    awsblueprints.io/provider: aws
     awsblueprints.io/environment: dev
+    awsblueprints.io/provider: aws
+  name: table.dynamodb.awsblueprints.io
 spec:
-  writeConnectionSecretsToNamespace: crossplane-system
   compositeTypeRef:
     apiVersion: awsblueprints.io/v1alpha1
     kind: XDynamoDBTable
-  patchSets:
-    - name: common-fields
-      patches:
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.providerConfigName
+  mode: Pipeline
+  pipeline:
+  - functionRef:
+      name: function-patch-and-transform
+    input:
+      apiVersion: pt.fn.crossplane.io/v1beta1
+      kind: Resources
+      patchSets:
+      - name: common-fields
+        patches:
+        - fromFieldPath: spec.resourceConfig.providerConfigName
           toFieldPath: spec.providerConfigRef.name
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.region
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.resourceConfig.region
           toFieldPath: spec.forProvider.region
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.name
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.resourceConfig.name
           toFieldPath: metadata.annotations[crossplane.io/external-name]
-  resources:
-    - name: table
-      connectionDetails:
-        - type: FromFieldPath
+          type: FromCompositeFieldPath
+      resources:
+      - base:
+          apiVersion: dynamodb.aws.upbound.io/v1beta1
+          kind: Table
+          spec:
+            forProvider:
+              writeConnectionSecretToRef:
+                namespace: crossplane-system
+        connectionDetails:
+        - fromFieldPath: status.atProvider.id
           name: tableName
-          fromFieldPath: status.atProvider.id
-      base:
-        apiVersion: dynamodb.aws.upbound.io/v1beta1
-        kind: Table
-        spec:
-          forProvider:
-            writeConnectionSecretToRef:
-              namespace: crossplane-system
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.dynamoConfig.attribute
+          type: FromFieldPath
+        name: table
+        patches:
+        - patchSetName: common-fields
+          type: PatchSet
+        - fromFieldPath: spec.dynamoConfig.attribute
+          policy:
+            toFieldPath: MergeObjectsAppendArrays
           toFieldPath: spec.forProvider.attribute
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.resourceConfig.tags
           policy:
-            mergeOptions:
-              appendSlice: true
-              keepMapValues: true
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.tags
+            toFieldPath: MergeObjects
           toFieldPath: spec.forProvider.tags
-          policy:
-            mergeOptions:
-              keepMapValues: true
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.dynamoConfig.hashKey
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.dynamoConfig.hashKey
           toFieldPath: spec.forProvider.hashKey
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.dynamoConfig.billingMode
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.dynamoConfig.billingMode
           toFieldPath: spec.forProvider.billingMode
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.dynamoConfig.rangeKey
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.dynamoConfig.rangeKey
           toFieldPath: spec.forProvider.rangeKey
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.dynamoConfig.readCapacity
-          toFieldPath: spec.forProvider.readCapacity 
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.dynamoConfig.writeCapacity
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.dynamoConfig.readCapacity
+          toFieldPath: spec.forProvider.readCapacity
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.dynamoConfig.writeCapacity
           toFieldPath: spec.forProvider.writeCapacity
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.dynamoConfig.globalSecondaryIndex
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.dynamoConfig.globalSecondaryIndex
+          policy:
+            toFieldPath: MergeObjects
           toFieldPath: spec.forProvider.globalSecondaryIndex
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.dynamoConfig.localSecondaryIndex
           policy:
-            mergeOptions:
-              keepMapValues: true
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.dynamoConfig.localSecondaryIndex
+            toFieldPath: MergeObjects
           toFieldPath: spec.forProvider.localSecondaryIndex
-          policy:
-            mergeOptions:
-              keepMapValues: true
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.atProvider.id
+          type: FromCompositeFieldPath
+        - fromFieldPath: status.atProvider.id
           toFieldPath: status.tableName
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.atProvider.arn
+          type: ToCompositeFieldPath
+        - fromFieldPath: status.atProvider.arn
           toFieldPath: status.tableArn
+          type: ToCompositeFieldPath
+    step: patch-and-transform
+  writeConnectionSecretsToNamespace: crossplane-system

--- a/compositions/upbound-aws-provider/dynamodb/table.yaml
+++ b/compositions/upbound-aws-provider/dynamodb/table.yaml
@@ -36,9 +36,9 @@ spec:
           apiVersion: dynamodb.aws.upbound.io/v1beta1
           kind: Table
           spec:
-            forProvider:
-              writeConnectionSecretToRef:
-                namespace: crossplane-system
+            forProvider: {}
+            writeConnectionSecretToRef:
+              namespace: crossplane-system
         connectionDetails:
         - fromFieldPath: status.atProvider.id
           name: tableName

--- a/compositions/upbound-aws-provider/iam-policy/cloudwatch-metrics-write.yaml
+++ b/compositions/upbound-aws-provider/iam-policy/cloudwatch-metrics-write.yaml
@@ -4,81 +4,92 @@
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
-  name: write-cloudwatch-metrics.iampolicy.awsblueprints.io
   labels:
-    awsblueprints.io/provider: aws
     awsblueprints.io/environment: dev
+    awsblueprints.io/provider: aws
     iam.awsblueprints.io/policy-type: write
     iam.awsblueprints.io/service: cloudwatch
     iam.awsblueprints.io/service-type: metrics
+  name: write-cloudwatch-metrics.iampolicy.awsblueprints.io
 spec:
   compositeTypeRef:
     apiVersion: awsblueprints.io/v1alpha1
     kind: IAMPolicy
-  patchSets:
-    - name: common-fields
-      patches:
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.deletionPolicy
+  mode: Pipeline
+  pipeline:
+  - functionRef:
+      name: function-patch-and-transform
+    input:
+      apiVersion: pt.fn.crossplane.io/v1beta1
+      kind: Resources
+      patchSets:
+      - name: common-fields
+        patches:
+        - fromFieldPath: spec.resourceConfig.deletionPolicy
           toFieldPath: spec.deletionPolicy
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.providerConfigName
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.resourceConfig.providerConfigName
           toFieldPath: spec.providerConfigRef.name
-        - fromFieldPath: "metadata.name"
-          toFieldPath: "metadata.name"
+          type: FromCompositeFieldPath
+        - fromFieldPath: metadata.name
+          toFieldPath: metadata.name
           transforms:
-            - type: string
-              string:
-                fmt: "policy-cw-metrics-write-%s"
-  resources:
-    - name: write-policy
-      base:
-        apiVersion: iam.aws.upbound.io/v1beta1
-        kind: Policy
-        spec:
-          deletionPolicy: Delete
-          forProvider: {}
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.tags
-          toFieldPath: spec.forProvider.tags
+          - string:
+              fmt: policy-cw-metrics-write-%s
+              type: Format
+            type: string
+          type: FromCompositeFieldPath
+      resources:
+      - base:
+          apiVersion: iam.aws.upbound.io/v1beta1
+          kind: Policy
+          spec:
+            deletionPolicy: Delete
+            forProvider: {}
+        name: write-policy
+        patches:
+        - patchSetName: common-fields
+          type: PatchSet
+        - fromFieldPath: spec.resourceConfig.tags
           policy:
-            mergeOptions:
-              keepMapValues: true
+            toFieldPath: MergeObjects
+          toFieldPath: spec.forProvider.tags
+          type: FromCompositeFieldPath
         - fromFieldPath: spec.resourceArn
           toFieldPath: spec.forProvider.policy
           transforms:
-            - type: string
-              string:
-                fmt: |
-                  {
-                    "Version": "2012-10-17",
-                    "Statement": [
-                      {
-                          "Action": [
-                              "cloudwatch:PutMetricData"
-                          ],
-                          "Resource": [
-                              "%s"
-                          ],
-                          "Effect": "Allow"
-                      }
-                    ]
-                  }
-    - name: policy-attachment
-      base:
-        apiVersion: iam.aws.upbound.io/v1beta1
-        kind: RolePolicyAttachment
-        spec:
-          deletionPolicy: Delete
-          forProvider:
-            policyArnSelector:
-              matchControllerRef: true
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.roleName
+          - string:
+              fmt: |
+                {
+                  "Version": "2012-10-17",
+                  "Statement": [
+                    {
+                        "Action": [
+                            "cloudwatch:PutMetricData"
+                        ],
+                        "Resource": [
+                            "%s"
+                        ],
+                        "Effect": "Allow"
+                    }
+                  ]
+                }
+              type: Format
+            type: string
+          type: FromCompositeFieldPath
+      - base:
+          apiVersion: iam.aws.upbound.io/v1beta1
+          kind: RolePolicyAttachment
+          spec:
+            deletionPolicy: Delete
+            forProvider:
+              policyArnSelector:
+                matchControllerRef: true
+        name: policy-attachment
+        patches:
+        - patchSetName: common-fields
+          type: PatchSet
+        - fromFieldPath: spec.roleName
           toFieldPath: spec.forProvider.role
+          type: FromCompositeFieldPath
+    step: patch-and-transform

--- a/compositions/upbound-aws-provider/iam-policy/dynamodb-write.yaml
+++ b/compositions/upbound-aws-provider/iam-policy/dynamodb-write.yaml
@@ -4,55 +4,57 @@
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
-  name: write-dynamodb.iampolicy.awsblueprints.io
   labels:
-    awsblueprints.io/provider: aws
     awsblueprints.io/environment: dev
+    awsblueprints.io/provider: aws
     iam.awsblueprints.io/policy-type: write
     iam.awsblueprints.io/service: dynamodb
+  name: write-dynamodb.iampolicy.awsblueprints.io
 spec:
   compositeTypeRef:
     apiVersion: awsblueprints.io/v1alpha1
     kind: IAMPolicy
-  patchSets:
-    - name: common-fields
-      patches:
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.deletionPolicy
+  mode: Pipeline
+  pipeline:
+  - functionRef:
+      name: function-patch-and-transform
+    input:
+      apiVersion: pt.fn.crossplane.io/v1beta1
+      kind: Resources
+      patchSets:
+      - name: common-fields
+        patches:
+        - fromFieldPath: spec.resourceConfig.deletionPolicy
           toFieldPath: spec.deletionPolicy
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.providerConfigName
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.resourceConfig.providerConfigName
           toFieldPath: spec.providerConfigRef.name
-        - fromFieldPath: "metadata.name"
-          toFieldPath: "metadata.name"
+          type: FromCompositeFieldPath
+        - fromFieldPath: metadata.name
+          toFieldPath: metadata.name
           transforms:
-            - type: string
-              string:
-                fmt: "policy-dynamodb-write-%s"
-  resources:
-    - name: write-policy
-      base:
-        apiVersion: iam.aws.upbound.io/v1beta1
-        kind: Policy
-        spec:
-          deletionPolicy: Delete
-          forProvider: {}
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.tags
-          toFieldPath: spec.forProvider.tags
+          - string:
+              fmt: policy-dynamodb-write-%s
+              type: Format
+            type: string
+          type: FromCompositeFieldPath
+      resources:
+      - base:
+          apiVersion: iam.aws.upbound.io/v1beta1
+          kind: Policy
+          spec:
+            deletionPolicy: Delete
+            forProvider: {}
+        name: write-policy
+        patches:
+        - patchSetName: common-fields
+          type: PatchSet
+        - fromFieldPath: spec.resourceConfig.tags
           policy:
-            mergeOptions:
-              keepMapValues: true
-        - type: CombineFromComposite
-          toFieldPath: spec.forProvider.policy
-          combine:
-            variables:
-            - fromFieldPath: spec.resourceArn
-            - fromFieldPath: spec.resourceArn
-            - fromFieldPath: spec.resourceArn
+            toFieldPath: MergeObjects
+          toFieldPath: spec.forProvider.tags
+          type: FromCompositeFieldPath
+        - combine:
             strategy: string
             string:
               fmt: |
@@ -95,18 +97,25 @@ spec:
                         }
                     ]
                 }
-    - name: policy-attachment
-      base:
-        apiVersion: iam.aws.upbound.io/v1beta1
-        kind: RolePolicyAttachment
-        spec:
-          deletionPolicy: Delete
-          forProvider:
-            policyArnSelector:
-              matchControllerRef: true
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.roleName
+            variables:
+            - fromFieldPath: spec.resourceArn
+            - fromFieldPath: spec.resourceArn
+            - fromFieldPath: spec.resourceArn
+          toFieldPath: spec.forProvider.policy
+          type: CombineFromComposite
+      - base:
+          apiVersion: iam.aws.upbound.io/v1beta1
+          kind: RolePolicyAttachment
+          spec:
+            deletionPolicy: Delete
+            forProvider:
+              policyArnSelector:
+                matchControllerRef: true
+        name: policy-attachment
+        patches:
+        - patchSetName: common-fields
+          type: PatchSet
+        - fromFieldPath: spec.roleName
           toFieldPath: spec.forProvider.role
+          type: FromCompositeFieldPath
+    step: patch-and-transform

--- a/compositions/upbound-aws-provider/iam-policy/firehose-write.yaml
+++ b/compositions/upbound-aws-provider/iam-policy/firehose-write.yaml
@@ -4,81 +4,92 @@
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
-  name: write-firehose.iampolicy.awsblueprints.io
   labels:
-    awsblueprints.io/provider: aws
     awsblueprints.io/environment: dev
+    awsblueprints.io/provider: aws
     iam.awsblueprints.io/policy-type: write
     iam.awsblueprints.io/service: firehose
+  name: write-firehose.iampolicy.awsblueprints.io
 spec:
   compositeTypeRef:
     apiVersion: awsblueprints.io/v1alpha1
     kind: IAMPolicy
-  patchSets:
-    - name: common-fields
-      patches:
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.deletionPolicy
+  mode: Pipeline
+  pipeline:
+  - functionRef:
+      name: function-patch-and-transform
+    input:
+      apiVersion: pt.fn.crossplane.io/v1beta1
+      kind: Resources
+      patchSets:
+      - name: common-fields
+        patches:
+        - fromFieldPath: spec.resourceConfig.deletionPolicy
           toFieldPath: spec.deletionPolicy
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.providerConfigName
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.resourceConfig.providerConfigName
           toFieldPath: spec.providerConfigRef.name
-        - fromFieldPath: "metadata.name"
-          toFieldPath: "metadata.name"
+          type: FromCompositeFieldPath
+        - fromFieldPath: metadata.name
+          toFieldPath: metadata.name
           transforms:
-            - type: string
-              string:
-                fmt: "policy-write-firehose-%s"
-  resources:
-    - name: invoke-policy
-      base:
-        apiVersion: iam.aws.upbound.io/v1beta1
-        kind: Policy
-        spec:
-          deletionPolicy: Delete
-          forProvider: {}
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.tags
-          toFieldPath: spec.forProvider.tags
+          - string:
+              fmt: policy-write-firehose-%s
+              type: Format
+            type: string
+          type: FromCompositeFieldPath
+      resources:
+      - base:
+          apiVersion: iam.aws.upbound.io/v1beta1
+          kind: Policy
+          spec:
+            deletionPolicy: Delete
+            forProvider: {}
+        name: invoke-policy
+        patches:
+        - patchSetName: common-fields
+          type: PatchSet
+        - fromFieldPath: spec.resourceConfig.tags
           policy:
-            mergeOptions:
-              keepMapValues: true
+            toFieldPath: MergeObjects
+          toFieldPath: spec.forProvider.tags
+          type: FromCompositeFieldPath
         - fromFieldPath: spec.resourceArn
           toFieldPath: spec.forProvider.policy
           transforms:
-            - type: string
-              string:
-                fmt: |
-                  {
-                    "Version": "2012-10-17",
-                    "Statement": [
-                      {
-                          "Action": [
-                              "firehose:PutRecord",
-                              "firehose:PutRecordBatch"
-                          ],
-                          "Resource": [
-                              "%s"
-                          ],
-                          "Effect": "Allow"
-                      }
-                    ]
-                  }
-    - name: policy-attachment
-      base:
-        apiVersion: iam.aws.upbound.io/v1beta1
-        kind: RolePolicyAttachment
-        spec:
-          deletionPolicy: Delete
-          forProvider:
-            policyArnSelector:
-              matchControllerRef: true
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.roleName
+          - string:
+              fmt: |
+                {
+                  "Version": "2012-10-17",
+                  "Statement": [
+                    {
+                        "Action": [
+                            "firehose:PutRecord",
+                            "firehose:PutRecordBatch"
+                        ],
+                        "Resource": [
+                            "%s"
+                        ],
+                        "Effect": "Allow"
+                    }
+                  ]
+                }
+              type: Format
+            type: string
+          type: FromCompositeFieldPath
+      - base:
+          apiVersion: iam.aws.upbound.io/v1beta1
+          kind: RolePolicyAttachment
+          spec:
+            deletionPolicy: Delete
+            forProvider:
+              policyArnSelector:
+                matchControllerRef: true
+        name: policy-attachment
+        patches:
+        - patchSetName: common-fields
+          type: PatchSet
+        - fromFieldPath: spec.roleName
           toFieldPath: spec.forProvider.role
+          type: FromCompositeFieldPath
+    step: patch-and-transform

--- a/compositions/upbound-aws-provider/iam-policy/kms-read.yaml
+++ b/compositions/upbound-aws-provider/iam-policy/kms-read.yaml
@@ -4,53 +4,57 @@
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
-  name: read-kms.iampolicy.awsblueprints.io
   labels:
-    awsblueprints.io/provider: aws
     awsblueprints.io/environment: dev
+    awsblueprints.io/provider: aws
     iam.awsblueprints.io/policy-type: read
     iam.awsblueprints.io/service: kms
+  name: read-kms.iampolicy.awsblueprints.io
 spec:
   compositeTypeRef:
     apiVersion: awsblueprints.io/v1alpha1
     kind: IAMPolicy
-  patchSets:
-    - name: common-fields
-      patches:
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.deletionPolicy
+  mode: Pipeline
+  pipeline:
+  - functionRef:
+      name: function-patch-and-transform
+    input:
+      apiVersion: pt.fn.crossplane.io/v1beta1
+      kind: Resources
+      patchSets:
+      - name: common-fields
+        patches:
+        - fromFieldPath: spec.resourceConfig.deletionPolicy
           toFieldPath: spec.deletionPolicy
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.providerConfigName
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.resourceConfig.providerConfigName
           toFieldPath: spec.providerConfigRef.name
-        - fromFieldPath: "metadata.name"
-          toFieldPath: "metadata.name"
+          type: FromCompositeFieldPath
+        - fromFieldPath: metadata.name
+          toFieldPath: metadata.name
           transforms:
-            - type: string
-              string:
-                fmt: "policy-kms-%s"
-  resources:
-    - name: read-policy
-      base:
-        apiVersion: iam.aws.upbound.io/v1beta1
-        kind: Policy
-        spec:
-          deletionPolicy: Delete
-          forProvider: {}
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.tags
-          toFieldPath: spec.forProvider.tags
+          - string:
+              fmt: policy-kms-%s
+              type: Format
+            type: string
+          type: FromCompositeFieldPath
+      resources:
+      - base:
+          apiVersion: iam.aws.upbound.io/v1beta1
+          kind: Policy
+          spec:
+            deletionPolicy: Delete
+            forProvider: {}
+        name: read-policy
+        patches:
+        - patchSetName: common-fields
+          type: PatchSet
+        - fromFieldPath: spec.resourceConfig.tags
           policy:
-            mergeOptions:
-              keepMapValues: true
-        - type: CombineFromComposite
-          toFieldPath: spec.forProvider.policy
-          combine:
-            variables:
-            - fromFieldPath: spec.resourceArn
+            toFieldPath: MergeObjects
+          toFieldPath: spec.forProvider.tags
+          type: FromCompositeFieldPath
+        - combine:
             strategy: string
             string:
               fmt: |
@@ -69,18 +73,23 @@ spec:
                     }
                   ]
                 }
-    - name: policy-attachment
-      base:
-        apiVersion: iam.aws.upbound.io/v1beta1
-        kind: RolePolicyAttachment
-        spec:
-          deletionPolicy: Delete
-          forProvider:
-            policyArnSelector:
-              matchControllerRef: true
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.roleName
+            variables:
+            - fromFieldPath: spec.resourceArn
+          toFieldPath: spec.forProvider.policy
+          type: CombineFromComposite
+      - base:
+          apiVersion: iam.aws.upbound.io/v1beta1
+          kind: RolePolicyAttachment
+          spec:
+            deletionPolicy: Delete
+            forProvider:
+              policyArnSelector:
+                matchControllerRef: true
+        name: policy-attachment
+        patches:
+        - patchSetName: common-fields
+          type: PatchSet
+        - fromFieldPath: spec.roleName
           toFieldPath: spec.forProvider.role
+          type: FromCompositeFieldPath
+    step: patch-and-transform

--- a/compositions/upbound-aws-provider/iam-policy/lambda-invoke.yaml
+++ b/compositions/upbound-aws-provider/iam-policy/lambda-invoke.yaml
@@ -4,81 +4,92 @@
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
-  name: lambda-invoke.iampolicy.awsblueprints.io
   labels:
-    awsblueprints.io/provider: aws
     awsblueprints.io/environment: dev
+    awsblueprints.io/provider: aws
     iam.awsblueprints.io/policy-type: invoke
     iam.awsblueprints.io/service: lambda
+  name: lambda-invoke.iampolicy.awsblueprints.io
 spec:
   compositeTypeRef:
     apiVersion: awsblueprints.io/v1alpha1
     kind: IAMPolicy
-  patchSets:
-    - name: common-fields
-      patches:
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.deletionPolicy
+  mode: Pipeline
+  pipeline:
+  - functionRef:
+      name: function-patch-and-transform
+    input:
+      apiVersion: pt.fn.crossplane.io/v1beta1
+      kind: Resources
+      patchSets:
+      - name: common-fields
+        patches:
+        - fromFieldPath: spec.resourceConfig.deletionPolicy
           toFieldPath: spec.deletionPolicy
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.providerConfigName
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.resourceConfig.providerConfigName
           toFieldPath: spec.providerConfigRef.name
-        - fromFieldPath: "metadata.name"
-          toFieldPath: "metadata.name"
+          type: FromCompositeFieldPath
+        - fromFieldPath: metadata.name
+          toFieldPath: metadata.name
           transforms:
-            - type: string
-              string:
-                fmt: "policy-invoke-lambda-%s"
-  resources:
-    - name: invoke-policy
-      base:
-        apiVersion: iam.aws.upbound.io/v1beta1
-        kind: Policy
-        spec:
-          deletionPolicy: Delete
-          forProvider: {}
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.tags
-          toFieldPath: spec.forProvider.tags
+          - string:
+              fmt: policy-invoke-lambda-%s
+              type: Format
+            type: string
+          type: FromCompositeFieldPath
+      resources:
+      - base:
+          apiVersion: iam.aws.upbound.io/v1beta1
+          kind: Policy
+          spec:
+            deletionPolicy: Delete
+            forProvider: {}
+        name: invoke-policy
+        patches:
+        - patchSetName: common-fields
+          type: PatchSet
+        - fromFieldPath: spec.resourceConfig.tags
           policy:
-            mergeOptions:
-              keepMapValues: true
+            toFieldPath: MergeObjects
+          toFieldPath: spec.forProvider.tags
+          type: FromCompositeFieldPath
         - fromFieldPath: spec.resourceArn
           toFieldPath: spec.forProvider.policy
           transforms:
-            - type: string
-              string:
-                fmt: |
-                  {
-                    "Version": "2012-10-17",
-                    "Statement": [
-                      {
-                          "Action": [
-                              "lambda:InvokeFunction",
-                              "lambda:GetFunctionConfiguration"
-                          ],
-                          "Resource": [
-                              "%s"
-                          ],
-                          "Effect": "Allow"
-                      }
-                    ]
-                  }
-    - name: policy-attachment
-      base:
-        apiVersion: iam.aws.upbound.io/v1beta1
-        kind: RolePolicyAttachment
-        spec:
-          deletionPolicy: Delete
-          forProvider:
-            policyArnSelector:
-              matchControllerRef: true
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.roleName
+          - string:
+              fmt: |
+                {
+                  "Version": "2012-10-17",
+                  "Statement": [
+                    {
+                        "Action": [
+                            "lambda:InvokeFunction",
+                            "lambda:GetFunctionConfiguration"
+                        ],
+                        "Resource": [
+                            "%s"
+                        ],
+                        "Effect": "Allow"
+                    }
+                  ]
+                }
+              type: Format
+            type: string
+          type: FromCompositeFieldPath
+      - base:
+          apiVersion: iam.aws.upbound.io/v1beta1
+          kind: RolePolicyAttachment
+          spec:
+            deletionPolicy: Delete
+            forProvider:
+              policyArnSelector:
+                matchControllerRef: true
+        name: policy-attachment
+        patches:
+        - patchSetName: common-fields
+          type: PatchSet
+        - fromFieldPath: spec.roleName
           toFieldPath: spec.forProvider.role
+          type: FromCompositeFieldPath
+    step: patch-and-transform

--- a/compositions/upbound-aws-provider/iam-policy/s3-read.yaml
+++ b/compositions/upbound-aws-provider/iam-policy/s3-read.yaml
@@ -7,54 +7,57 @@
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
-  name: read-s3.iampolicy.awsblueprints.io
   labels:
-    awsblueprints.io/provider: aws
     awsblueprints.io/environment: dev
+    awsblueprints.io/provider: aws
     iam.awsblueprints.io/policy-type: read
     iam.awsblueprints.io/service: s3
+  name: read-s3.iampolicy.awsblueprints.io
 spec:
   compositeTypeRef:
     apiVersion: awsblueprints.io/v1alpha1
     kind: IAMPolicy
-  patchSets:
-    - name: common-fields
-      patches:
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.deletionPolicy
+  mode: Pipeline
+  pipeline:
+  - functionRef:
+      name: function-patch-and-transform
+    input:
+      apiVersion: pt.fn.crossplane.io/v1beta1
+      kind: Resources
+      patchSets:
+      - name: common-fields
+        patches:
+        - fromFieldPath: spec.resourceConfig.deletionPolicy
           toFieldPath: spec.deletionPolicy
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.providerConfigName
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.resourceConfig.providerConfigName
           toFieldPath: spec.providerConfigRef.name
-        - fromFieldPath: "metadata.name"
-          toFieldPath: "metadata.name"
+          type: FromCompositeFieldPath
+        - fromFieldPath: metadata.name
+          toFieldPath: metadata.name
           transforms:
-            - type: string
-              string:
-                fmt: "policy-s3-read-%s"
-  resources:
-    - name: read-policy
-      base:
-        apiVersion: iam.aws.upbound.io/v1beta1
-        kind: Policy
-        spec:
-          deletionPolicy: Delete
-          forProvider: {}
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.tags
-          toFieldPath: spec.forProvider.tags
+          - string:
+              fmt: policy-s3-read-%s
+              type: Format
+            type: string
+          type: FromCompositeFieldPath
+      resources:
+      - base:
+          apiVersion: iam.aws.upbound.io/v1beta1
+          kind: Policy
+          spec:
+            deletionPolicy: Delete
+            forProvider: {}
+        name: read-policy
+        patches:
+        - patchSetName: common-fields
+          type: PatchSet
+        - fromFieldPath: spec.resourceConfig.tags
           policy:
-            mergeOptions:
-              keepMapValues: true
-        - type: CombineFromComposite
-          toFieldPath: spec.forProvider.policy
-          combine:
-            variables:
-            - fromFieldPath: spec.resourceArn
-            - fromFieldPath: spec.resourceArn
+            toFieldPath: MergeObjects
+          toFieldPath: spec.forProvider.tags
+          type: FromCompositeFieldPath
+        - combine:
             strategy: string
             string:
               fmt: |
@@ -81,18 +84,24 @@ spec:
                     }
                   ]
                 }
-    - name: policy-attachment
-      base:
-        apiVersion: iam.aws.upbound.io/v1beta1
-        kind: RolePolicyAttachment
-        spec:
-          deletionPolicy: Delete
-          forProvider:
-            policyArnSelector:
-              matchControllerRef: true
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.roleName
+            variables:
+            - fromFieldPath: spec.resourceArn
+            - fromFieldPath: spec.resourceArn
+          toFieldPath: spec.forProvider.policy
+          type: CombineFromComposite
+      - base:
+          apiVersion: iam.aws.upbound.io/v1beta1
+          kind: RolePolicyAttachment
+          spec:
+            deletionPolicy: Delete
+            forProvider:
+              policyArnSelector:
+                matchControllerRef: true
+        name: policy-attachment
+        patches:
+        - patchSetName: common-fields
+          type: PatchSet
+        - fromFieldPath: spec.roleName
           toFieldPath: spec.forProvider.role
+          type: FromCompositeFieldPath
+    step: patch-and-transform

--- a/compositions/upbound-aws-provider/iam-policy/s3-write-firehose.yaml
+++ b/compositions/upbound-aws-provider/iam-policy/s3-write-firehose.yaml
@@ -4,54 +4,57 @@
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
-  name: write-firehose-s3.iampolicy.awsblueprints.io
   labels:
-    awsblueprints.io/provider: aws
     awsblueprints.io/environment: dev
+    awsblueprints.io/provider: aws
     iam.awsblueprints.io/policy-type: write
     iam.awsblueprints.io/service: firehose-s3
+  name: write-firehose-s3.iampolicy.awsblueprints.io
 spec:
   compositeTypeRef:
     apiVersion: awsblueprints.io/v1alpha1
     kind: IAMPolicy
-  patchSets:
-    - name: common-fields
-      patches:
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.deletionPolicy
+  mode: Pipeline
+  pipeline:
+  - functionRef:
+      name: function-patch-and-transform
+    input:
+      apiVersion: pt.fn.crossplane.io/v1beta1
+      kind: Resources
+      patchSets:
+      - name: common-fields
+        patches:
+        - fromFieldPath: spec.resourceConfig.deletionPolicy
           toFieldPath: spec.deletionPolicy
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.providerConfigName
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.resourceConfig.providerConfigName
           toFieldPath: spec.providerConfigRef.name
-        - fromFieldPath: "metadata.name"
-          toFieldPath: "metadata.name"
+          type: FromCompositeFieldPath
+        - fromFieldPath: metadata.name
+          toFieldPath: metadata.name
           transforms:
-            - type: string
-              string:
-                fmt: "policy-s3-write-firehose-%s"
-  resources:
-    - name: write-policy
-      base:
-        apiVersion: iam.aws.upbound.io/v1beta1
-        kind: Policy
-        spec:
-          deletionPolicy: Delete
-          forProvider: {}
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.tags
-          toFieldPath: spec.forProvider.tags
+          - string:
+              fmt: policy-s3-write-firehose-%s
+              type: Format
+            type: string
+          type: FromCompositeFieldPath
+      resources:
+      - base:
+          apiVersion: iam.aws.upbound.io/v1beta1
+          kind: Policy
+          spec:
+            deletionPolicy: Delete
+            forProvider: {}
+        name: write-policy
+        patches:
+        - patchSetName: common-fields
+          type: PatchSet
+        - fromFieldPath: spec.resourceConfig.tags
           policy:
-            mergeOptions:
-              keepMapValues: true
-        - type: CombineFromComposite
-          toFieldPath: spec.forProvider.policy
-          combine:
-            variables:
-            - fromFieldPath: spec.resourceArn
-            - fromFieldPath: spec.resourceArn
+            toFieldPath: MergeObjects
+          toFieldPath: spec.forProvider.tags
+          type: FromCompositeFieldPath
+        - combine:
             strategy: string
             string:
               fmt: |
@@ -75,18 +78,24 @@ spec:
                     }
                   ]
                 }
-    - name: policy-attachment
-      base:
-        apiVersion: iam.aws.upbound.io/v1beta1
-        kind: RolePolicyAttachment
-        spec:
-          deletionPolicy: Delete
-          forProvider:
-            policyArnSelector:
-              matchControllerRef: true
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.roleName
+            variables:
+            - fromFieldPath: spec.resourceArn
+            - fromFieldPath: spec.resourceArn
+          toFieldPath: spec.forProvider.policy
+          type: CombineFromComposite
+      - base:
+          apiVersion: iam.aws.upbound.io/v1beta1
+          kind: RolePolicyAttachment
+          spec:
+            deletionPolicy: Delete
+            forProvider:
+              policyArnSelector:
+                matchControllerRef: true
+        name: policy-attachment
+        patches:
+        - patchSetName: common-fields
+          type: PatchSet
+        - fromFieldPath: spec.roleName
           toFieldPath: spec.forProvider.role
+          type: FromCompositeFieldPath
+    step: patch-and-transform

--- a/compositions/upbound-aws-provider/iam-policy/s3-write.yaml
+++ b/compositions/upbound-aws-provider/iam-policy/s3-write.yaml
@@ -4,54 +4,57 @@
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
-  name: write-s3.iampolicy.awsblueprints.io
   labels:
-    awsblueprints.io/provider: aws
     awsblueprints.io/environment: dev
+    awsblueprints.io/provider: aws
     iam.awsblueprints.io/policy-type: write
     iam.awsblueprints.io/service: s3
+  name: write-s3.iampolicy.awsblueprints.io
 spec:
   compositeTypeRef:
     apiVersion: awsblueprints.io/v1alpha1
     kind: IAMPolicy
-  patchSets:
-    - name: common-fields
-      patches:
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.deletionPolicy
+  mode: Pipeline
+  pipeline:
+  - functionRef:
+      name: function-patch-and-transform
+    input:
+      apiVersion: pt.fn.crossplane.io/v1beta1
+      kind: Resources
+      patchSets:
+      - name: common-fields
+        patches:
+        - fromFieldPath: spec.resourceConfig.deletionPolicy
           toFieldPath: spec.deletionPolicy
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.providerConfigName
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.resourceConfig.providerConfigName
           toFieldPath: spec.providerConfigRef.name
-        - fromFieldPath: "metadata.name"
-          toFieldPath: "metadata.name"
+          type: FromCompositeFieldPath
+        - fromFieldPath: metadata.name
+          toFieldPath: metadata.name
           transforms:
-            - type: string
-              string:
-                fmt: "policy-s3-write-%s"
-  resources:
-    - name: write-policy
-      base:
-        apiVersion: iam.aws.upbound.io/v1beta1
-        kind: Policy
-        spec:
-          deletionPolicy: Delete
-          forProvider: {}
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.tags
-          toFieldPath: spec.forProvider.tags
+          - string:
+              fmt: policy-s3-write-%s
+              type: Format
+            type: string
+          type: FromCompositeFieldPath
+      resources:
+      - base:
+          apiVersion: iam.aws.upbound.io/v1beta1
+          kind: Policy
+          spec:
+            deletionPolicy: Delete
+            forProvider: {}
+        name: write-policy
+        patches:
+        - patchSetName: common-fields
+          type: PatchSet
+        - fromFieldPath: spec.resourceConfig.tags
           policy:
-            mergeOptions:
-              keepMapValues: true
-        - type: CombineFromComposite
-          toFieldPath: spec.forProvider.policy
-          combine:
-            variables:
-            - fromFieldPath: spec.resourceArn
-            - fromFieldPath: spec.resourceArn
+            toFieldPath: MergeObjects
+          toFieldPath: spec.forProvider.tags
+          type: FromCompositeFieldPath
+        - combine:
             strategy: string
             string:
               fmt: |
@@ -82,18 +85,24 @@ spec:
                     }
                   ]
                 }
-    - name: policy-attachment
-      base:
-        apiVersion: iam.aws.upbound.io/v1beta1
-        kind: RolePolicyAttachment
-        spec:
-          deletionPolicy: Delete
-          forProvider:
-            policyArnSelector:
-              matchControllerRef: true
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.roleName
+            variables:
+            - fromFieldPath: spec.resourceArn
+            - fromFieldPath: spec.resourceArn
+          toFieldPath: spec.forProvider.policy
+          type: CombineFromComposite
+      - base:
+          apiVersion: iam.aws.upbound.io/v1beta1
+          kind: RolePolicyAttachment
+          spec:
+            deletionPolicy: Delete
+            forProvider:
+              policyArnSelector:
+                matchControllerRef: true
+        name: policy-attachment
+        patches:
+        - patchSetName: common-fields
+          type: PatchSet
+        - fromFieldPath: spec.roleName
           toFieldPath: spec.forProvider.role
+          type: FromCompositeFieldPath
+    step: patch-and-transform

--- a/compositions/upbound-aws-provider/iam-policy/sqs-read.yaml
+++ b/compositions/upbound-aws-provider/iam-policy/sqs-read.yaml
@@ -4,53 +4,57 @@
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
-  name: read-sqs.iampolicy.awsblueprints.io
   labels:
-    awsblueprints.io/provider: aws
     awsblueprints.io/environment: dev
+    awsblueprints.io/provider: aws
     iam.awsblueprints.io/policy-type: read
     iam.awsblueprints.io/service: sqs
+  name: read-sqs.iampolicy.awsblueprints.io
 spec:
   compositeTypeRef:
     apiVersion: awsblueprints.io/v1alpha1
     kind: IAMPolicy
-  patchSets:
-    - name: common-fields
-      patches:
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.deletionPolicy
+  mode: Pipeline
+  pipeline:
+  - functionRef:
+      name: function-patch-and-transform
+    input:
+      apiVersion: pt.fn.crossplane.io/v1beta1
+      kind: Resources
+      patchSets:
+      - name: common-fields
+        patches:
+        - fromFieldPath: spec.resourceConfig.deletionPolicy
           toFieldPath: spec.deletionPolicy
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.providerConfigName
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.resourceConfig.providerConfigName
           toFieldPath: spec.providerConfigRef.name
-        - fromFieldPath: "metadata.name"
-          toFieldPath: "metadata.name"
+          type: FromCompositeFieldPath
+        - fromFieldPath: metadata.name
+          toFieldPath: metadata.name
           transforms:
-            - type: string
-              string:
-                fmt: "policy-sqs-read-%s"
-  resources:
-    - name: read-policy
-      base:
-        apiVersion: iam.aws.upbound.io/v1beta1
-        kind: Policy
-        spec:
-          deletionPolicy: Delete
-          forProvider: {}
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.tags
-          toFieldPath: spec.forProvider.tags
+          - string:
+              fmt: policy-sqs-read-%s
+              type: Format
+            type: string
+          type: FromCompositeFieldPath
+      resources:
+      - base:
+          apiVersion: iam.aws.upbound.io/v1beta1
+          kind: Policy
+          spec:
+            deletionPolicy: Delete
+            forProvider: {}
+        name: read-policy
+        patches:
+        - patchSetName: common-fields
+          type: PatchSet
+        - fromFieldPath: spec.resourceConfig.tags
           policy:
-            mergeOptions:
-              keepMapValues: true
-        - type: CombineFromComposite
-          toFieldPath: spec.forProvider.policy
-          combine:
-            variables:
-            - fromFieldPath: spec.resourceArn
+            toFieldPath: MergeObjects
+          toFieldPath: spec.forProvider.tags
+          type: FromCompositeFieldPath
+        - combine:
             strategy: string
             string:
               fmt: |
@@ -70,18 +74,23 @@ spec:
                     }
                   ]
                 }
-    - name: policy-attachment
-      base:
-        apiVersion: iam.aws.upbound.io/v1beta1
-        kind: RolePolicyAttachment
-        spec:
-          deletionPolicy: Delete
-          forProvider:
-            policyArnSelector:
-              matchControllerRef: true
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.roleName
+            variables:
+            - fromFieldPath: spec.resourceArn
+          toFieldPath: spec.forProvider.policy
+          type: CombineFromComposite
+      - base:
+          apiVersion: iam.aws.upbound.io/v1beta1
+          kind: RolePolicyAttachment
+          spec:
+            deletionPolicy: Delete
+            forProvider:
+              policyArnSelector:
+                matchControllerRef: true
+        name: policy-attachment
+        patches:
+        - patchSetName: common-fields
+          type: PatchSet
+        - fromFieldPath: spec.roleName
           toFieldPath: spec.forProvider.role
+          type: FromCompositeFieldPath
+    step: patch-and-transform

--- a/compositions/upbound-aws-provider/iam-policy/sqs-write.yaml
+++ b/compositions/upbound-aws-provider/iam-policy/sqs-write.yaml
@@ -4,53 +4,57 @@
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
-  name: write-sqs.iampolicy.awsblueprints.io
   labels:
-    awsblueprints.io/provider: aws
     awsblueprints.io/environment: dev
+    awsblueprints.io/provider: aws
     iam.awsblueprints.io/policy-type: write
     iam.awsblueprints.io/service: sqs
+  name: write-sqs.iampolicy.awsblueprints.io
 spec:
   compositeTypeRef:
     apiVersion: awsblueprints.io/v1alpha1
     kind: IAMPolicy
-  patchSets:
-    - name: common-fields
-      patches:
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.deletionPolicy
+  mode: Pipeline
+  pipeline:
+  - functionRef:
+      name: function-patch-and-transform
+    input:
+      apiVersion: pt.fn.crossplane.io/v1beta1
+      kind: Resources
+      patchSets:
+      - name: common-fields
+        patches:
+        - fromFieldPath: spec.resourceConfig.deletionPolicy
           toFieldPath: spec.deletionPolicy
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.providerConfigName
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.resourceConfig.providerConfigName
           toFieldPath: spec.providerConfigRef.name
-        - fromFieldPath: "metadata.name"
-          toFieldPath: "metadata.name"
+          type: FromCompositeFieldPath
+        - fromFieldPath: metadata.name
+          toFieldPath: metadata.name
           transforms:
-            - type: string
-              string:
-                fmt: "policy-sqs-write-%s"
-  resources:
-    - name: write-policy
-      base:
-        apiVersion: iam.aws.upbound.io/v1beta1
-        kind: Policy
-        spec:
-          deletionPolicy: Delete
-          forProvider: {}
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.tags
-          toFieldPath: spec.forProvider.tags
+          - string:
+              fmt: policy-sqs-write-%s
+              type: Format
+            type: string
+          type: FromCompositeFieldPath
+      resources:
+      - base:
+          apiVersion: iam.aws.upbound.io/v1beta1
+          kind: Policy
+          spec:
+            deletionPolicy: Delete
+            forProvider: {}
+        name: write-policy
+        patches:
+        - patchSetName: common-fields
+          type: PatchSet
+        - fromFieldPath: spec.resourceConfig.tags
           policy:
-            mergeOptions:
-              keepMapValues: true
-        - type: CombineFromComposite
-          toFieldPath: spec.forProvider.policy
-          combine:
-            variables:
-            - fromFieldPath: spec.resourceArn
+            toFieldPath: MergeObjects
+          toFieldPath: spec.forProvider.tags
+          type: FromCompositeFieldPath
+        - combine:
             strategy: string
             string:
               fmt: |
@@ -69,18 +73,23 @@ spec:
                     }
                   ]
                 }
-    - name: policy-attachment
-      base:
-        apiVersion: iam.aws.upbound.io/v1beta1
-        kind: RolePolicyAttachment
-        spec:
-          deletionPolicy: Delete
-          forProvider:
-            policyArnSelector:
-              matchControllerRef: true
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.roleName
+            variables:
+            - fromFieldPath: spec.resourceArn
+          toFieldPath: spec.forProvider.policy
+          type: CombineFromComposite
+      - base:
+          apiVersion: iam.aws.upbound.io/v1beta1
+          kind: RolePolicyAttachment
+          spec:
+            deletionPolicy: Delete
+            forProvider:
+              policyArnSelector:
+                matchControllerRef: true
+        name: policy-attachment
+        patches:
+        - patchSetName: common-fields
+          type: PatchSet
+        - fromFieldPath: spec.roleName
           toFieldPath: spec.forProvider.role
+          type: FromCompositeFieldPath
+    step: patch-and-transform

--- a/compositions/upbound-aws-provider/irsa/irsa.yaml
+++ b/compositions/upbound-aws-provider/irsa/irsa.yaml
@@ -1,6 +1,4 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: Apache-2.0
-
+---
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
@@ -9,73 +7,77 @@ spec:
   compositeTypeRef:
     apiVersion: awsblueprints.io/v1alpha1
     kind: XIRSA
-  environment:
-    environmentConfigs:
-      - type: Reference
-        ref:
-          name: cluster
-  patchSets:
-    - name: common-fields
-      patches:
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.providerConfigName
+  mode: Pipeline
+  pipeline:
+  - functionRef:
+      name: function-environment-configs
+    input:
+      apiVersion: environmentconfigs.fn.crossplane.io/v1beta1
+      kind: Input
+      spec:
+        environmentConfigs:
+        - ref:
+            name: cluster
+          type: Reference
+    step: environment-configs
+  - functionRef:
+      name: function-patch-and-transform
+    input:
+      apiVersion: pt.fn.crossplane.io/v1beta1
+      kind: Resources
+      patchSets:
+      - name: common-fields
+        patches:
+        - fromFieldPath: spec.resourceConfig.providerConfigName
           toFieldPath: spec.providerConfigRef.name
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.deletionPolicy
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.resourceConfig.deletionPolicy
           toFieldPath: spec.deletionPolicy
-  resources:
-    - name: iam-role
-      base:
-        apiVersion: iam.aws.upbound.io/v1beta1
-        kind: Role
-        spec:
-          forProvider:
-            assumeRolePolicy: ""
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields
-        - type: FromEnvironmentFieldPath
-          fromFieldPath: awsAccountID
+          type: FromCompositeFieldPath
+      resources:
+      - base:
+          apiVersion: iam.aws.upbound.io/v1beta1
+          kind: Role
+          spec:
+            forProvider:
+              assumeRolePolicy: ""
+        name: iam-role
+        patches:
+        - patchSetName: common-fields
+          type: PatchSet
+        - fromFieldPath: awsAccountID
           toFieldPath: metadata.annotations[crossplane.io/awsaccountid]
-        - type: ToCompositeFieldPath
-          fromFieldPath: metadata.annotations[crossplane.io/awsaccountid]
+          type: FromEnvironmentFieldPath
+        - fromFieldPath: metadata.annotations[crossplane.io/awsaccountid]
+          policy:
+            fromFieldPath: Required
           toFieldPath: status.awsAccountID
-          policy:
-            fromFieldPath: Required
-        - type: FromEnvironmentFieldPath
-          fromFieldPath: eksOIDC
+          type: ToCompositeFieldPath
+        - fromFieldPath: eksOIDC
           toFieldPath: metadata.annotations[crossplane.io/eksoidc]
-        - type: ToCompositeFieldPath
-          fromFieldPath: metadata.annotations[crossplane.io/eksoidc]
-          toFieldPath: status.eksOIDC
+          type: FromEnvironmentFieldPath
+        - fromFieldPath: metadata.annotations[crossplane.io/eksoidc]
           policy:
             fromFieldPath: Required
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.atProvider.arn
+          toFieldPath: status.eksOIDC
+          type: ToCompositeFieldPath
+        - fromFieldPath: status.atProvider.arn
           toFieldPath: status.roleArn
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.atProvider.arn
+          type: ToCompositeFieldPath
+        - fromFieldPath: status.atProvider.arn
           toFieldPath: status.roleName
           transforms:
-            - type: string
-              string:
-                type: Regexp
-                regexp:
-                  match: 'arn:aws:iam::(\d+):role/(.*)'
-                  group: 2
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.permissionsBoundaryArn
+          - string:
+              regexp:
+                group: 2
+                match: arn:aws:iam::(\d+):role/(.*)
+              type: Regexp
+            type: string
+          type: ToCompositeFieldPath
+        - fromFieldPath: spec.permissionsBoundaryArn
           toFieldPath: spec.forProvider.permissionsBoundary
-        - type: CombineFromComposite
-          toFieldPath: spec.forProvider.assumeRolePolicy
-          combine:
-            variables:
-            - fromFieldPath: status.awsAccountID
-            - fromFieldPath: status.eksOIDC
-            - fromFieldPath: status.eksOIDC
-            - fromFieldPath: status.eksOIDC
-            - fromFieldPath: metadata.labels[crossplane.io/claim-namespace]
-            - fromFieldPath: spec.serviceAccountName
+          type: FromCompositeFieldPath
+        - combine:
             strategy: string
             string:
               fmt: |
@@ -97,29 +99,39 @@ spec:
                     }
                   ]
                 }
-    - name: service-account
-      base:
-        apiVersion: kubernetes.crossplane.io/v1alpha1
-        kind: Object
-        spec:
-          forProvider:
-            manifest:
-              apiVersion: v1
-              kind: ServiceAccount
-              metadata:
-                name: ""
-                namespace: default
-                annotations:
-                  eks.amazonaws.com/role-arn: ""
-      patches:
-        - type: FromCompositeFieldPath
-          fromFieldPath: metadata.labels[crossplane.io/claim-namespace]
+            variables:
+            - fromFieldPath: status.awsAccountID
+            - fromFieldPath: status.eksOIDC
+            - fromFieldPath: status.eksOIDC
+            - fromFieldPath: status.eksOIDC
+            - fromFieldPath: metadata.labels[crossplane.io/claim-namespace]
+            - fromFieldPath: spec.serviceAccountName
+          toFieldPath: spec.forProvider.assumeRolePolicy
+          type: CombineFromComposite
+      - base:
+          apiVersion: kubernetes.crossplane.io/v1alpha1
+          kind: Object
+          spec:
+            forProvider:
+              manifest:
+                apiVersion: v1
+                kind: ServiceAccount
+                metadata:
+                  annotations:
+                    eks.amazonaws.com/role-arn: ""
+                  name: ""
+                  namespace: default
+        name: service-account
+        patches:
+        - fromFieldPath: metadata.labels[crossplane.io/claim-namespace]
           toFieldPath: spec.forProvider.manifest.metadata.namespace
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.serviceAccountName
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.serviceAccountName
           toFieldPath: spec.forProvider.manifest.metadata.name
-        - type: FromCompositeFieldPath
-          fromFieldPath: status.roleArn
-          toFieldPath: spec.forProvider.manifest.metadata.annotations[eks.amazonaws.com/role-arn]
+          type: FromCompositeFieldPath
+        - fromFieldPath: status.roleArn
           policy:
             fromFieldPath: Required
+          toFieldPath: spec.forProvider.manifest.metadata.annotations[eks.amazonaws.com/role-arn]
+          type: FromCompositeFieldPath
+    step: patch-and-transform

--- a/compositions/upbound-aws-provider/kinesis-data-firehose-app/log-forwarder.yaml
+++ b/compositions/upbound-aws-provider/kinesis-data-firehose-app/log-forwarder.yaml
@@ -1,153 +1,165 @@
-
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
-  name: firehose.upbound.awsblueprints.io
   annotations:
     argocd.argoproj.io/sync-wave: "-10"
   labels:
-    awsblueprints.io/provider: aws
     awsblueprints.io/environment: dev
+    awsblueprints.io/provider: aws
     kinesis.awsblueprints.io/app: firehose
     kinesis.awsblueprints.io/destination: s3
+  name: firehose.upbound.awsblueprints.io
 spec:
   compositeTypeRef:
     apiVersion: awsblueprints.io/v1alpha1
     kind: XFirehoseApp
-  patchSets:
-    - name: common-fields-composition
-      patches:
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig
-          toFieldPath: spec.resourceConfig
-    - name: common-fields
-      patches:
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.deletionPolicy
-          toFieldPath: spec.deletionPolicy
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.region
-          toFieldPath: spec.forProvider.region
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.tags
-          toFieldPath: spec.forProvider.tags
-          policy:
-            mergeOptions:
-              keepMapValues: true
-        - fromFieldPath: "metadata.name"
-          toFieldPath: "metadata.name"
-  environment:
-    environmentConfigs:
-      - type: Selector
-        selector:
-          matchLabels:
-          - key: awsblueprints.io/environment
-            valueFromFieldPath: spec.environmentConfigs
-  resources:
-    - name: lambda
-      base:
-        apiVersion: awsblueprints.io/v1alpha1
-        kind: XLambdaFunction
-        spec:
-          compositionSelector:
+  mode: Pipeline
+  pipeline:
+  - functionRef:
+      name: function-environment-configs
+    input:
+      apiVersion: environmentconfigs.fn.crossplane.io/v1beta1
+      kind: Input
+      spec:
+        environmentConfigs:
+        - selector:
             matchLabels:
-              awsblueprints.io/provider: aws
-              awsblueprints.io/environment: dev
-              awsblueprints.io/type: zip
-          runTime: python3.8
-          handler: index.handler
-          memorySize: 256
-          timeout: 60
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields-composition
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.envVariables
+            - key: awsblueprints.io/environment
+              valueFromFieldPath: spec.environmentConfigs
+          type: Selector
+    step: environment-configs
+  - functionRef:
+      name: function-patch-and-transform
+    input:
+      apiVersion: pt.fn.crossplane.io/v1beta1
+      kind: Resources
+      patchSets:
+      - name: common-fields-composition
+        patches:
+        - fromFieldPath: spec.resourceConfig
+          toFieldPath: spec.resourceConfig
+          type: FromCompositeFieldPath
+      - name: common-fields
+        patches:
+        - fromFieldPath: spec.resourceConfig.deletionPolicy
+          toFieldPath: spec.deletionPolicy
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.resourceConfig.region
+          toFieldPath: spec.forProvider.region
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.resourceConfig.tags
+          policy:
+            toFieldPath: MergeObjects
+          toFieldPath: spec.forProvider.tags
+          type: FromCompositeFieldPath
+        - fromFieldPath: metadata.name
+          toFieldPath: metadata.name
+          type: FromCompositeFieldPath
+      resources:
+      - base:
+          apiVersion: awsblueprints.io/v1alpha1
+          kind: XLambdaFunction
+          spec:
+            compositionSelector:
+              matchLabels:
+                awsblueprints.io/environment: dev
+                awsblueprints.io/provider: aws
+                awsblueprints.io/type: zip
+            handler: index.handler
+            memorySize: 256
+            runTime: python3.8
+            timeout: 60
+        name: lambda
+        patches:
+        - patchSetName: common-fields-composition
+          type: PatchSet
+        - fromFieldPath: spec.envVariables
           toFieldPath: spec.envVariables
-        - type: FromEnvironmentFieldPath
-          fromFieldPath: bucketName
+          type: FromCompositeFieldPath
+        - fromFieldPath: bucketName
           toFieldPath: spec.bucketName
-        - type: FromEnvironmentFieldPath
-          fromFieldPath: bucketKey
+          type: FromEnvironmentFieldPath
+        - fromFieldPath: bucketKey
           toFieldPath: spec.bucketKey
-        - type: FromEnvironmentFieldPath
-          fromFieldPath: DYNATRACE_API_KEY
+          type: FromEnvironmentFieldPath
+        - fromFieldPath: DYNATRACE_API_KEY
           toFieldPath: spec.envVariables.DYNATRACE_API_KEY
-        - type: FromEnvironmentFieldPath
-          fromFieldPath: DYNATRACE_ENV_URL
+          type: FromEnvironmentFieldPath
+        - fromFieldPath: DYNATRACE_ENV_URL
           toFieldPath: spec.envVariables.DYNATRACE_ENV_URL
-        - type: FromCompositeFieldPath
-          fromFieldPath: metadata.name
+          type: FromEnvironmentFieldPath
+        - fromFieldPath: metadata.name
           toFieldPath: metadata.name
           transforms:
-            - type: string
-              string:
-                fmt: "%s-processor"
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.functionRoleName
+          - string:
+              fmt: '%s-processor'
+              type: Format
+            type: string
+          type: FromCompositeFieldPath
+        - fromFieldPath: status.functionRoleName
           toFieldPath: status.processorRoleName
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.functionName
+          type: ToCompositeFieldPath
+        - fromFieldPath: status.functionName
           toFieldPath: status.processorFuncName
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.functionArn
+          type: ToCompositeFieldPath
+        - fromFieldPath: status.functionArn
           toFieldPath: status.processorFuncArn
-    - name: bucket
-      base:
-        apiVersion: awsblueprints.io/v1alpha1
-        kind: XObjectStorage
-        metadata:
-          name: standard-object-storage
-        spec:
-          compositionSelector:
-            matchLabels:
-              awsblueprints.io/provider: aws
-              awsblueprints.io/environment: dev
-              s3.awsblueprints.io/configuration: standard
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields-composition
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.bucketName
+          type: ToCompositeFieldPath
+      - base:
+          apiVersion: awsblueprints.io/v1alpha1
+          kind: XObjectStorage
+          metadata:
+            name: standard-object-storage
+          spec:
+            compositionSelector:
+              matchLabels:
+                awsblueprints.io/environment: dev
+                awsblueprints.io/provider: aws
+                s3.awsblueprints.io/configuration: standard
+        name: bucket
+        patches:
+        - patchSetName: common-fields-composition
+          type: PatchSet
+        - fromFieldPath: status.bucketName
           toFieldPath: status.bucketName
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.bucketArn
+          type: ToCompositeFieldPath
+        - fromFieldPath: status.bucketArn
           toFieldPath: status.bucketArn
-    - name: lambda-metrics-write
-      base:
-        apiVersion: awsblueprints.io/v1alpha1
-        kind: IAMPolicy
-        spec:
-          resourceArn: "*"
-          compositionSelector:
-            matchLabels:
-              awsblueprints.io/provider: aws
-              awsblueprints.io/environment: dev
-              iam.awsblueprints.io/policy-type: write
-              iam.awsblueprints.io/service: cloudwatch
-              iam.awsblueprints.io/service-type: metrics
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields-composition
-        - type: FromCompositeFieldPath
-          fromFieldPath: status.processorRoleName
+          type: ToCompositeFieldPath
+      - base:
+          apiVersion: awsblueprints.io/v1alpha1
+          kind: IAMPolicy
+          spec:
+            compositionSelector:
+              matchLabels:
+                awsblueprints.io/environment: dev
+                awsblueprints.io/provider: aws
+                iam.awsblueprints.io/policy-type: write
+                iam.awsblueprints.io/service: cloudwatch
+                iam.awsblueprints.io/service-type: metrics
+            resourceArn: '*'
+        name: lambda-metrics-write
+        patches:
+        - patchSetName: common-fields-composition
+          type: PatchSet
+        - fromFieldPath: status.processorRoleName
           toFieldPath: spec.roleName
-    - name: kinesis-firehose
-      base:
-        apiVersion: awsblueprints.io/v1alpha1
-        kind: XKinesisFirehose
-        metadata:
-        spec:
-          forProvider:
-            destination: extended_s3
-            extendedS3Configuration:
+          type: FromCompositeFieldPath
+      - base:
+          apiVersion: awsblueprints.io/v1alpha1
+          kind: XKinesisFirehose
+          metadata: null
+          spec:
+            forProvider:
+              destination: extended_s3
+              extendedS3Configuration:
               - bufferInterval: 60
                 bufferSize: 5
                 compressionFormat: GZIP
-                prefix: "success-"
+                prefix: success-
                 processingConfiguration:
                 - enabled: true
                   processors:
@@ -155,151 +167,153 @@ spec:
                     - parameterName: LambdaArn
                       parameterValue: TBD
                     type: Lambda
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields-composition
-        # We want to pass down a custom label for deliverystreams.firehose.aws.upbound.io CR
-        # This will allow us to find this CR with matchSelector in subscriptionfilters.cloudwatchlogs.aws.upbound.io CRs
-        - type: FromCompositeFieldPath
-          fromFieldPath: metadata.labels
-          toFieldPath: metadata.labels
+        name: kinesis-firehose
+        patches:
+        - patchSetName: common-fields-composition
+          type: PatchSet
+        - fromFieldPath: metadata.labels
           policy:
-            mergeOptions:
-              keepMapValues: true
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.region
+            toFieldPath: MergeObjects
+          toFieldPath: metadata.labels
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.resourceConfig.region
           toFieldPath: spec.forProvider.region
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.name
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.name
           toFieldPath: spec.forProvider.name
-        - type: FromCompositeFieldPath
-          fromFieldPath: status.bucketName
+          type: FromCompositeFieldPath
+        - fromFieldPath: status.bucketName
           toFieldPath: spec.forProvider.extendedS3Configuration[0].bucketArnRef.name
-        - type: FromCompositeFieldPath
-          fromFieldPath: status.kinesisRoleName
+          type: FromCompositeFieldPath
+        - fromFieldPath: status.kinesisRoleName
           toFieldPath: spec.forProvider.extendedS3Configuration[0].roleArnRef.name
-        - type: FromCompositeFieldPath
-          fromFieldPath: status.processorFuncArn
+          type: FromCompositeFieldPath
+        - fromFieldPath: status.processorFuncArn
           toFieldPath: spec.forProvider.extendedS3Configuration[0].processingConfiguration[0].processors[0].parameters[0].parameterValue
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.kinesisRoleArn
+          type: FromCompositeFieldPath
+        - fromFieldPath: status.kinesisRoleArn
           toFieldPath: status.kinesisRoleArn
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.kinesisRoleName
+          type: ToCompositeFieldPath
+        - fromFieldPath: status.kinesisRoleName
           toFieldPath: status.kinesisRoleName
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.kinesisName
+          type: ToCompositeFieldPath
+        - fromFieldPath: status.kinesisName
           toFieldPath: status.kinesisName
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.kinesisArn
+          type: ToCompositeFieldPath
+        - fromFieldPath: status.kinesisArn
           toFieldPath: status.kinesisArn
-    - name: kinesis-write-s3
-      base:
-        apiVersion: awsblueprints.io/v1alpha1
-        kind: IAMPolicy
-        spec:
-          compositionSelector:
-            matchLabels:
-              awsblueprints.io/provider: aws
-              awsblueprints.io/environment: dev
+          type: ToCompositeFieldPath
+      - base:
+          apiVersion: awsblueprints.io/v1alpha1
+          kind: IAMPolicy
+          spec:
+            compositionSelector:
+              matchLabels:
+                awsblueprints.io/environment: dev
+                awsblueprints.io/provider: aws
+                iam.awsblueprints.io/policy-type: write
+                iam.awsblueprints.io/service: firehose-s3
+        name: kinesis-write-s3
+        patches:
+        - patchSetName: common-fields-composition
+          type: PatchSet
+        - fromFieldPath: status.kinesisRoleName
+          toFieldPath: spec.roleName
+          type: FromCompositeFieldPath
+        - fromFieldPath: status.bucketArn
+          toFieldPath: spec.resourceArn
+          type: FromCompositeFieldPath
+      - base:
+          apiVersion: awsblueprints.io/v1alpha1
+          kind: IAMPolicy
+          spec:
+            compositionSelector:
+              matchLabels:
+                awsblueprints.io/environment: dev
+                awsblueprints.io/provider: aws
+                iam.awsblueprints.io/policy-type: invoke
+                iam.awsblueprints.io/service: lambda
+        name: kinesis-invoke-lambda
+        patches:
+        - patchSetName: common-fields-composition
+          type: PatchSet
+        - fromFieldPath: status.kinesisRoleName
+          toFieldPath: spec.roleName
+          type: FromCompositeFieldPath
+        - fromFieldPath: status.processorFuncArn
+          toFieldPath: spec.resourceArn
+          type: FromCompositeFieldPath
+      - base:
+          apiVersion: iam.aws.upbound.io/v1beta1
+          kind: Role
+          metadata:
+            labels:
               iam.awsblueprints.io/policy-type: write
-              iam.awsblueprints.io/service: firehose-s3
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields-composition
-        - type: FromCompositeFieldPath
-          fromFieldPath: status.kinesisRoleName
-          toFieldPath: spec.roleName
-        - type: FromCompositeFieldPath
-          fromFieldPath: status.bucketArn
-          toFieldPath: spec.resourceArn
-    - name: kinesis-invoke-lambda
-      base:
-        apiVersion: awsblueprints.io/v1alpha1
-        kind: IAMPolicy
-        spec:
-          compositionSelector:
-            matchLabels:
-              awsblueprints.io/provider: aws
-              awsblueprints.io/environment: dev
-              iam.awsblueprints.io/policy-type: invoke
-              iam.awsblueprints.io/service: lambda
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields-composition
-        - type: FromCompositeFieldPath
-          fromFieldPath: status.kinesisRoleName
-          toFieldPath: spec.roleName
-        - type: FromCompositeFieldPath
-          fromFieldPath: status.processorFuncArn
-          toFieldPath: spec.resourceArn
-    - name: logs-write-firehose-role
-      base:
-        apiVersion: iam.aws.upbound.io/v1beta1
-        kind: Role
-        metadata:
-          labels:
-            iam.awsblueprints.io/policy-type: write
-            iam.awsblueprints.io/service: firehose
-        spec:
-          forProvider: {}
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields
+              iam.awsblueprints.io/service: firehose
+          spec:
+            forProvider: {}
+        name: logs-write-firehose-role
+        patches:
+        - patchSetName: common-fields
+          type: PatchSet
         - fromFieldPath: spec.resourceConfig.region
           toFieldPath: spec.forProvider.assumeRolePolicy
           transforms:
-            - type: string
-              string:
-                fmt: |
-                  {
-                    "Version": "2012-10-17",
-                    "Statement": [
-                      {
-                        "Effect": "Allow",
-                        "Principal": {
-                          "Service": "logs.%s.amazonaws.com"
-                        },
-                        "Action": "sts:AssumeRole"
-                      }
-                    ]
-                  }
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.providerConfigName
+          - string:
+              fmt: |
+                {
+                  "Version": "2012-10-17",
+                  "Statement": [
+                    {
+                      "Effect": "Allow",
+                      "Principal": {
+                        "Service": "logs.%s.amazonaws.com"
+                      },
+                      "Action": "sts:AssumeRole"
+                    }
+                  ]
+                }
+              type: Format
+            type: string
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.resourceConfig.providerConfigName
           toFieldPath: spec.providerConfigRef.name
-        - type: FromCompositeFieldPath
-          fromFieldPath: metadata.name
+          type: FromCompositeFieldPath
+        - fromFieldPath: metadata.name
           toFieldPath: metadata.name
           transforms:
-            - type: string
-              string:
-                fmt: "%s-firehose-write-role"
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.atProvider.arn
+          - string:
+              fmt: '%s-firehose-write-role'
+              type: Format
+            type: string
+          type: FromCompositeFieldPath
+        - fromFieldPath: status.atProvider.arn
           toFieldPath: status.cloudwatchlogsRoleArn
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.atProvider.id
+          type: ToCompositeFieldPath
+        - fromFieldPath: status.atProvider.id
           toFieldPath: status.cloudwatchlogsRoleName
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.permissionsBoundaryArn
+          type: ToCompositeFieldPath
+        - fromFieldPath: spec.permissionsBoundaryArn
           toFieldPath: spec.forProvider.permissionsBoundary
-    - name: logs-write-firehose-policy
-      base:
-        apiVersion: awsblueprints.io/v1alpha1
-        kind: IAMPolicy
-        spec:
-          compositionSelector:
-            matchLabels:
-              awsblueprints.io/provider: aws
-              awsblueprints.io/environment: dev
-              iam.awsblueprints.io/policy-type: write
-              iam.awsblueprints.io/service: firehose
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields-composition
-        - type: FromCompositeFieldPath
-          fromFieldPath: status.cloudwatchlogsRoleName
+          type: FromCompositeFieldPath
+      - base:
+          apiVersion: awsblueprints.io/v1alpha1
+          kind: IAMPolicy
+          spec:
+            compositionSelector:
+              matchLabels:
+                awsblueprints.io/environment: dev
+                awsblueprints.io/provider: aws
+                iam.awsblueprints.io/policy-type: write
+                iam.awsblueprints.io/service: firehose
+        name: logs-write-firehose-policy
+        patches:
+        - patchSetName: common-fields-composition
+          type: PatchSet
+        - fromFieldPath: status.cloudwatchlogsRoleName
           toFieldPath: spec.roleName
-        - type: FromCompositeFieldPath
-          fromFieldPath: status.kinesisArn
+          type: FromCompositeFieldPath
+        - fromFieldPath: status.kinesisArn
           toFieldPath: spec.resourceArn
+          type: FromCompositeFieldPath
+    step: patch-and-transform

--- a/compositions/upbound-aws-provider/kinesis-data-firehose/kinesis-data-firehose.yaml
+++ b/compositions/upbound-aws-provider/kinesis-data-firehose/kinesis-data-firehose.yaml
@@ -1,102 +1,108 @@
-
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
-  name: kinesisfirehose.upbound.awsblueprints.io
   annotations:
     argocd.argoproj.io/sync-wave: "-10"
   labels:
-    awsblueprints.io/provider: aws
     awsblueprints.io/environment: dev
+    awsblueprints.io/provider: aws
     kinesis.awsblueprints.io/service: firehose
+  name: kinesisfirehose.upbound.awsblueprints.io
 spec:
   compositeTypeRef:
     apiVersion: awsblueprints.io/v1alpha1
     kind: XKinesisFirehose
-  patchSets:
-    - name: common-fields
-      patches:
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.deletionPolicy
+  mode: Pipeline
+  pipeline:
+  - functionRef:
+      name: function-patch-and-transform
+    input:
+      apiVersion: pt.fn.crossplane.io/v1beta1
+      kind: Resources
+      patchSets:
+      - name: common-fields
+        patches:
+        - fromFieldPath: spec.resourceConfig.deletionPolicy
           toFieldPath: spec.deletionPolicy
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.region
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.resourceConfig.region
           toFieldPath: spec.forProvider.region
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.tags
-          toFieldPath: spec.forProvider.tags
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.resourceConfig.tags
           policy:
-            mergeOptions:
-              keepMapValues: true
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.name
+            toFieldPath: MergeObjects
+          toFieldPath: spec.forProvider.tags
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.resourceConfig.name
           toFieldPath: metadata.annotations[crossplane.io/external-name]
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.providerConfigName
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.resourceConfig.providerConfigName
           toFieldPath: spec.providerConfigRef.name
-        - type: FromCompositeFieldPath
-          fromFieldPath: metadata.name
+          type: FromCompositeFieldPath
+        - fromFieldPath: metadata.name
           toFieldPath: metadata.name
           transforms:
-            - type: string
-              string:
-                fmt: "kinesis-%s"
-        - type: FromCompositeFieldPath  # Labels are required because they are later used by SubscriptionFilter matchlabel selector
-          fromFieldPath: metadata.labels
-          toFieldPath: metadata.labels
+          - string:
+              fmt: kinesis-%s
+              type: Format
+            type: string
+          type: FromCompositeFieldPath
+        - fromFieldPath: metadata.labels
           policy:
-            mergeOptions:
-              keepMapValues: true
-  resources:
-    - name: kinesis-firehose
-      base:
-        apiVersion: firehose.aws.upbound.io/v1beta1
-        kind: DeliveryStream
-        spec:
-          forProvider: {}
-      patches:
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.forProvider
+            toFieldPath: MergeObjects
+          toFieldPath: metadata.labels
+          type: FromCompositeFieldPath
+      resources:
+      - base:
+          apiVersion: firehose.aws.upbound.io/v1beta1
+          kind: DeliveryStream
+          spec:
+            forProvider: {}
+        name: kinesis-firehose
+        patches:
+        - fromFieldPath: spec.forProvider
           toFieldPath: spec.forProvider
-        - type: PatchSet
-          patchSetName: common-fields
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.atProvider.id
+          type: FromCompositeFieldPath
+        - patchSetName: common-fields
+          type: PatchSet
+        - fromFieldPath: status.atProvider.id
           toFieldPath: status.kinesisArn
-        - type: ToCompositeFieldPath
-          fromFieldPath: metadata.name
+          type: ToCompositeFieldPath
+        - fromFieldPath: metadata.name
           toFieldPath: status.kinesisName
-    - name: kinesis-role
-      base:
-        apiVersion: iam.aws.upbound.io/v1beta1
-        kind: Role
-        spec:
-          forProvider:
-            assumeRolePolicy: |
-              {
-                "Version": "2012-10-17",
-                "Statement": [
-                  {
-                    "Effect": "Allow",
-                    "Principal": {
-                      "Service": "firehose.amazonaws.com"
-                    },
-                    "Action": "sts:AssumeRole"
-                  }
-                ]
-              }
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.atProvider.arn
+          type: ToCompositeFieldPath
+      - base:
+          apiVersion: iam.aws.upbound.io/v1beta1
+          kind: Role
+          spec:
+            forProvider:
+              assumeRolePolicy: |
+                {
+                  "Version": "2012-10-17",
+                  "Statement": [
+                    {
+                      "Effect": "Allow",
+                      "Principal": {
+                        "Service": "firehose.amazonaws.com"
+                      },
+                      "Action": "sts:AssumeRole"
+                    }
+                  ]
+                }
+        name: kinesis-role
+        patches:
+        - patchSetName: common-fields
+          type: PatchSet
+        - fromFieldPath: status.atProvider.arn
           toFieldPath: status.kinesisRoleArn
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.atProvider.id
+          type: ToCompositeFieldPath
+        - fromFieldPath: status.atProvider.id
           toFieldPath: status.kinesisRoleName
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.permissionsBoundaryArn
+          type: ToCompositeFieldPath
+        - fromFieldPath: spec.permissionsBoundaryArn
           toFieldPath: spec.forProvider.permissionsBoundary
+          type: FromCompositeFieldPath
+    step: patch-and-transform

--- a/compositions/upbound-aws-provider/kms/kms.yaml
+++ b/compositions/upbound-aws-provider/kms/kms.yaml
@@ -4,67 +4,74 @@
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
-  name: xencryptionkeys-kms.awsblueprints.io
   labels:
     awsblueprints.io/environment: dev
     awsblueprints.io/provider: aws
+  name: xencryptionkeys-kms.awsblueprints.io
 spec:
   compositeTypeRef:
     apiVersion: awsblueprints.io/v1alpha1
     kind: XEncryptionKey
-  patchSets:
-    - name: common-fields
-      patches:
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.deletionPolicy
+  mode: Pipeline
+  pipeline:
+  - functionRef:
+      name: function-patch-and-transform
+    input:
+      apiVersion: pt.fn.crossplane.io/v1beta1
+      kind: Resources
+      patchSets:
+      - name: common-fields
+        patches:
+        - fromFieldPath: spec.resourceConfig.deletionPolicy
           toFieldPath: spec.deletionPolicy
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.region
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.resourceConfig.region
           toFieldPath: spec.forProvider.region
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.providerConfigName
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.resourceConfig.providerConfigName
           toFieldPath: spec.providerConfigRef.name
-  resources:
-    - name: key
-      base:
-        apiVersion: kms.aws.upbound.io/v1beta1
-        kind: Key
-        spec:
-          forProvider:
-            description: "for use with this account"
-            deletionWindowInDays: 10
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.policy
+          type: FromCompositeFieldPath
+      resources:
+      - base:
+          apiVersion: kms.aws.upbound.io/v1beta1
+          kind: Key
+          spec:
+            forProvider:
+              deletionWindowInDays: 10
+              description: for use with this account
+        name: key
+        patches:
+        - patchSetName: common-fields
+          type: PatchSet
+        - fromFieldPath: spec.policy
           toFieldPath: spec.forProvider.policy
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.atProvider.arn
+          type: FromCompositeFieldPath
+        - fromFieldPath: status.atProvider.arn
           toFieldPath: status.keyArn
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.atProvider.keyId
+          type: ToCompositeFieldPath
+        - fromFieldPath: status.atProvider.keyId
           toFieldPath: status.keyId
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.tags
-          toFieldPath: spec.forProvider.tags
+          type: ToCompositeFieldPath
+        - fromFieldPath: spec.resourceConfig.tags
           policy:
-            mergeOptions:
-              keepMapValues: true
-    - name: alais
-      base:
-        apiVersion: kms.aws.upbound.io/v1beta1
-        kind: Alias
-        spec:
-          forProvider: {}
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields
-        - type: FromCompositeFieldPath
-          fromFieldPath: status.keyId
-          toFieldPath: spec.forProvider.targetKeyId
+            toFieldPath: MergeObjects
+          toFieldPath: spec.forProvider.tags
+          type: FromCompositeFieldPath
+      - base:
+          apiVersion: kms.aws.upbound.io/v1beta1
+          kind: Alias
+          spec:
+            forProvider: {}
+        name: alais
+        patches:
+        - patchSetName: common-fields
+          type: PatchSet
+        - fromFieldPath: status.keyId
           policy:
             fromFieldPath: Required
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.atProvider.id
+          toFieldPath: spec.forProvider.targetKeyId
+          type: FromCompositeFieldPath
+        - fromFieldPath: status.atProvider.id
           toFieldPath: status.keyName
+          type: ToCompositeFieldPath
+    step: patch-and-transform

--- a/compositions/upbound-aws-provider/kms/kms.yaml
+++ b/compositions/upbound-aws-provider/kms/kms.yaml
@@ -62,7 +62,7 @@ spec:
           kind: Alias
           spec:
             forProvider: {}
-        name: alais
+        name: alias
         patches:
         - patchSetName: common-fields
           type: PatchSet

--- a/compositions/upbound-aws-provider/lambda/container.yaml
+++ b/compositions/upbound-aws-provider/lambda/container.yaml
@@ -4,132 +4,139 @@
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
-  name: container.lambda.aws.upbound.awsblueprints.io
   labels:
-    awsblueprints.io/provider: aws
     awsblueprints.io/environment: dev
+    awsblueprints.io/provider: aws
     awsblueprints.io/type: container
+  name: container.lambda.aws.upbound.awsblueprints.io
 spec:
   compositeTypeRef:
     apiVersion: awsblueprints.io/v1alpha1
     kind: XLambdaFunction
-  patchSets:
-    - name: common-fields
-      patches:
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.deletionPolicy
+  mode: Pipeline
+  pipeline:
+  - functionRef:
+      name: function-patch-and-transform
+    input:
+      apiVersion: pt.fn.crossplane.io/v1beta1
+      kind: Resources
+      patchSets:
+      - name: common-fields
+        patches:
+        - fromFieldPath: spec.resourceConfig.deletionPolicy
           toFieldPath: spec.deletionPolicy
-        - fromFieldPath: "metadata.name"
-          toFieldPath: "metadata.name"
-  resources:
-    - name: function-role
-      base:
-        apiVersion: iam.aws.upbound.io/v1beta1
-        kind: Role
-        spec:
-          forProvider:
-            assumeRolePolicy: |
-              {
-                "Version": "2012-10-17",
-                "Statement": [
-                  {
-                    "Effect": "Allow",
-                    "Principal": {
-                      "Service": "lambda.amazonaws.com"
-                    },
-                    "Action": "sts:AssumeRole"
-                  }
-                ]
-              }
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.providerConfigName
+          type: FromCompositeFieldPath
+        - fromFieldPath: metadata.name
+          toFieldPath: metadata.name
+          type: FromCompositeFieldPath
+      resources:
+      - base:
+          apiVersion: iam.aws.upbound.io/v1beta1
+          kind: Role
+          spec:
+            forProvider:
+              assumeRolePolicy: |
+                {
+                  "Version": "2012-10-17",
+                  "Statement": [
+                    {
+                      "Effect": "Allow",
+                      "Principal": {
+                        "Service": "lambda.amazonaws.com"
+                      },
+                      "Action": "sts:AssumeRole"
+                    }
+                  ]
+                }
+        name: function-role
+        patches:
+        - patchSetName: common-fields
+          type: PatchSet
+        - fromFieldPath: spec.resourceConfig.providerConfigName
           toFieldPath: spec.providerConfigRef.name
-        - type: FromCompositeFieldPath
-          fromFieldPath: metadata.name
+          type: FromCompositeFieldPath
+        - fromFieldPath: metadata.name
           toFieldPath: metadata.name
           transforms:
-            - type: string
-              string:
-                fmt: "%s-role"
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.atProvider.arn
+          - string:
+              fmt: '%s-role'
+              type: Format
+            type: string
+          type: FromCompositeFieldPath
+        - fromFieldPath: status.atProvider.arn
           toFieldPath: status.functionRoleArn
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.atProvider.id
+          type: ToCompositeFieldPath
+        - fromFieldPath: status.atProvider.id
           toFieldPath: status.functionRoleName
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.permissionsBoundaryArn
+          type: ToCompositeFieldPath
+        - fromFieldPath: spec.permissionsBoundaryArn
           toFieldPath: spec.forProvider.permissionsBoundary
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.tags
-          toFieldPath: spec.forProvider.tags
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.resourceConfig.tags
           policy:
-            mergeOptions:
-              keepMapValues: true
-    - name: lambda-basic-policy-attachment
-      base:
-        apiVersion: iam.aws.upbound.io/v1beta1
-        kind: RolePolicyAttachment
-        spec:
-          forProvider:
-            policyArn: arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
-            roleSelector:
-              matchControllerRef: true
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.providerConfigName
+            toFieldPath: MergeObjects
+          toFieldPath: spec.forProvider.tags
+          type: FromCompositeFieldPath
+      - base:
+          apiVersion: iam.aws.upbound.io/v1beta1
+          kind: RolePolicyAttachment
+          spec:
+            forProvider:
+              policyArn: arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+              roleSelector:
+                matchControllerRef: true
+        name: lambda-basic-policy-attachment
+        patches:
+        - patchSetName: common-fields
+          type: PatchSet
+        - fromFieldPath: spec.resourceConfig.providerConfigName
           toFieldPath: spec.providerConfigRef.name
-    - name: function
-      base:
-        apiVersion: lambda.aws.upbound.io/v1beta1
-        kind: Function
-        spec:
-          deletionPolicy: Delete
-          forProvider:
-            packageType: Image
-            environment:
+          type: FromCompositeFieldPath
+      - base:
+          apiVersion: lambda.aws.upbound.io/v1beta1
+          kind: Function
+          spec:
+            deletionPolicy: Delete
+            forProvider:
+              environment:
               - variables: {}
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.region
+              packageType: Image
+        name: function
+        patches:
+        - patchSetName: common-fields
+          type: PatchSet
+        - fromFieldPath: spec.resourceConfig.region
           toFieldPath: spec.forProvider.region
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.providerConfigName
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.resourceConfig.providerConfigName
           toFieldPath: spec.providerConfigRef.name
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.memorySize
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.memorySize
           toFieldPath: spec.forProvider.memorySize
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.timeout
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.timeout
           toFieldPath: spec.forProvider.timeout
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.imageUri
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.imageUri
           toFieldPath: spec.forProvider.imageUri
-        - type: FromCompositeFieldPath
-          fromFieldPath: status.functionRoleArn
+          type: FromCompositeFieldPath
+        - fromFieldPath: status.functionRoleArn
           toFieldPath: spec.forProvider.role
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.envVariables
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.envVariables
+          policy:
+            toFieldPath: MergeObjects
           toFieldPath: spec.forProvider.environment[0].variables
-          policy:
-            mergeOptions:
-              keepMapValues: true
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.atProvider.arn
+          type: FromCompositeFieldPath
+        - fromFieldPath: status.atProvider.arn
           toFieldPath: status.functionArn
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.atProvider.id
+          type: ToCompositeFieldPath
+        - fromFieldPath: status.atProvider.id
           toFieldPath: status.functionName
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.tags
-          toFieldPath: spec.forProvider.tags
+          type: ToCompositeFieldPath
+        - fromFieldPath: spec.resourceConfig.tags
           policy:
-            mergeOptions:
-              keepMapValues: true
+            toFieldPath: MergeObjects
+          toFieldPath: spec.forProvider.tags
+          type: FromCompositeFieldPath
+    step: patch-and-transform

--- a/compositions/upbound-aws-provider/lambda/zip.yaml
+++ b/compositions/upbound-aws-provider/lambda/zip.yaml
@@ -4,151 +4,158 @@
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
-  name: s3.lambda.aws.upbound.awsblueprints.io
   labels:
-    awsblueprints.io/provider: aws
     awsblueprints.io/environment: dev
+    awsblueprints.io/provider: aws
     awsblueprints.io/type: zip
+  name: s3.lambda.aws.upbound.awsblueprints.io
 spec:
   compositeTypeRef:
     apiVersion: awsblueprints.io/v1alpha1
     kind: XLambdaFunction
-  patchSets:
-    - name: common-fields
-      patches:
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.deletionPolicy
+  mode: Pipeline
+  pipeline:
+  - functionRef:
+      name: function-patch-and-transform
+    input:
+      apiVersion: pt.fn.crossplane.io/v1beta1
+      kind: Resources
+      patchSets:
+      - name: common-fields
+        patches:
+        - fromFieldPath: spec.resourceConfig.deletionPolicy
           toFieldPath: spec.deletionPolicy
-        - fromFieldPath: "metadata.name"
-          toFieldPath: "metadata.name"
-  resources:
-    - name: function-role
-      base:
-        apiVersion: iam.aws.upbound.io/v1beta1
-        kind: Role
-        spec:
-          forProvider:
-            assumeRolePolicy: |
-              {
-                "Version": "2012-10-17",
-                "Statement": [
-                  {
-                    "Effect": "Allow",
-                    "Principal": {
-                      "Service": "lambda.amazonaws.com"
-                    },
-                    "Action": "sts:AssumeRole"
-                  }
-                ]
-              }
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.providerConfigName
+          type: FromCompositeFieldPath
+        - fromFieldPath: metadata.name
+          toFieldPath: metadata.name
+          type: FromCompositeFieldPath
+      resources:
+      - base:
+          apiVersion: iam.aws.upbound.io/v1beta1
+          kind: Role
+          spec:
+            forProvider:
+              assumeRolePolicy: |
+                {
+                  "Version": "2012-10-17",
+                  "Statement": [
+                    {
+                      "Effect": "Allow",
+                      "Principal": {
+                        "Service": "lambda.amazonaws.com"
+                      },
+                      "Action": "sts:AssumeRole"
+                    }
+                  ]
+                }
+        name: function-role
+        patches:
+        - patchSetName: common-fields
+          type: PatchSet
+        - fromFieldPath: spec.resourceConfig.providerConfigName
           toFieldPath: spec.providerConfigRef.name
-        - type: FromCompositeFieldPath
-          fromFieldPath: metadata.name
+          type: FromCompositeFieldPath
+        - fromFieldPath: metadata.name
           toFieldPath: metadata.name
           transforms:
-            - type: string
-              string:
-                fmt: "%s-role"
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.atProvider.arn
+          - string:
+              fmt: '%s-role'
+              type: Format
+            type: string
+          type: FromCompositeFieldPath
+        - fromFieldPath: status.atProvider.arn
           toFieldPath: status.functionRoleArn
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.atProvider.id
+          type: ToCompositeFieldPath
+        - fromFieldPath: status.atProvider.id
           toFieldPath: status.functionRoleName
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.permissionsBoundaryArn
+          type: ToCompositeFieldPath
+        - fromFieldPath: spec.permissionsBoundaryArn
           toFieldPath: spec.forProvider.permissionsBoundary
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.tags
-          toFieldPath: spec.forProvider.tags
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.resourceConfig.tags
           policy:
-            mergeOptions:
-              keepMapValues: true
-    - name: lambda-basic-policy-attachment
-      base:
-        apiVersion: iam.aws.upbound.io/v1beta1
-        kind: RolePolicyAttachment
-        spec:
-          forProvider:
-            policyArn: arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
-            roleSelector:
-              matchControllerRef: true
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.providerConfigName
+            toFieldPath: MergeObjects
+          toFieldPath: spec.forProvider.tags
+          type: FromCompositeFieldPath
+      - base:
+          apiVersion: iam.aws.upbound.io/v1beta1
+          kind: RolePolicyAttachment
+          spec:
+            forProvider:
+              policyArn: arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+              roleSelector:
+                matchControllerRef: true
+        name: lambda-basic-policy-attachment
+        patches:
+        - patchSetName: common-fields
+          type: PatchSet
+        - fromFieldPath: spec.resourceConfig.providerConfigName
           toFieldPath: spec.providerConfigRef.name
-    - name: function
-      base:
-        apiVersion: lambda.aws.upbound.io/v1beta1
-        kind: Function
-        spec:
-          deletionPolicy: Delete
-          forProvider:
-            packageType: Zip
-            role: "tbd"
-            environment:
+          type: FromCompositeFieldPath
+      - base:
+          apiVersion: lambda.aws.upbound.io/v1beta1
+          kind: Function
+          spec:
+            deletionPolicy: Delete
+            forProvider:
+              environment:
               - variables:
                   hardcoded: value
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.providerConfigName
+              packageType: Zip
+              role: tbd
+        name: function
+        patches:
+        - patchSetName: common-fields
+          type: PatchSet
+        - fromFieldPath: spec.resourceConfig.providerConfigName
           toFieldPath: spec.providerConfigRef.name
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.memorySize
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.memorySize
           toFieldPath: spec.forProvider.memorySize
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.timeout
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.timeout
           toFieldPath: spec.forProvider.timeout
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.runTime
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.runTime
+          policy:
+            fromFieldPath: Required
           toFieldPath: spec.forProvider.runtime
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.handler
           policy:
             fromFieldPath: Required
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.handler
           toFieldPath: spec.forProvider.handler
-          policy:
-            fromFieldPath: Required
-        - type: FromCompositeFieldPath
-          fromFieldPath: status.functionRoleArn
+          type: FromCompositeFieldPath
+        - fromFieldPath: status.functionRoleArn
           toFieldPath: spec.forProvider.role
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.bucketName
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.bucketName
+          policy:
+            fromFieldPath: Required
           toFieldPath: spec.forProvider.s3Bucket
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.bucketKey
           policy:
             fromFieldPath: Required
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.bucketKey
           toFieldPath: spec.forProvider.s3Key
-          policy:
-            fromFieldPath: Required
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.region
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.resourceConfig.region
           toFieldPath: spec.forProvider.region
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.envVariables
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.envVariables
+          policy:
+            toFieldPath: MergeObjects
           toFieldPath: spec.forProvider.environment[0].variables
-          policy:
-            mergeOptions:
-              keepMapValues: true
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.atProvider.arn
+          type: FromCompositeFieldPath
+        - fromFieldPath: status.atProvider.arn
           toFieldPath: status.functionArn
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.atProvider.id
+          type: ToCompositeFieldPath
+        - fromFieldPath: status.atProvider.id
           toFieldPath: status.functionName
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.tags
-          toFieldPath: spec.forProvider.tags
+          type: ToCompositeFieldPath
+        - fromFieldPath: spec.resourceConfig.tags
           policy:
-            mergeOptions:
-              keepMapValues: true
+            toFieldPath: MergeObjects
+          toFieldPath: spec.forProvider.tags
+          type: FromCompositeFieldPath
+    step: patch-and-transform

--- a/compositions/upbound-aws-provider/s3/general-purpose.yaml
+++ b/compositions/upbound-aws-provider/s3/general-purpose.yaml
@@ -57,8 +57,8 @@ spec:
             forProvider:
               forceDestroy: true
               region: us-west-2
-              writeConnectionSecretToRef:
-                namespace: crossplane-system
+            writeConnectionSecretToRef:
+              namespace: crossplane-system
         connectionDetails:
         - fromFieldPath: status.atProvider.id
           name: bucketName

--- a/compositions/upbound-aws-provider/s3/general-purpose.yaml
+++ b/compositions/upbound-aws-provider/s3/general-purpose.yaml
@@ -57,8 +57,6 @@ spec:
             forProvider:
               forceDestroy: true
               region: us-west-2
-            writeConnectionSecretToRef:
-              namespace: crossplane-system
         connectionDetails:
         - fromFieldPath: status.atProvider.id
           name: bucketName

--- a/compositions/upbound-aws-provider/s3/general-purpose.yaml
+++ b/compositions/upbound-aws-provider/s3/general-purpose.yaml
@@ -4,105 +4,118 @@
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
-  name: s3bucket.awsblueprints.io
   labels:
-    awsblueprints.io/provider: aws
     awsblueprints.io/environment: dev
+    awsblueprints.io/provider: aws
     s3.awsblueprints.io/configuration: standard
+  name: s3bucket.awsblueprints.io
 spec:
-  writeConnectionSecretsToNamespace: crossplane-system
   compositeTypeRef:
     apiVersion: awsblueprints.io/v1alpha1
     kind: XObjectStorage
-  patchSets:
-    - name: common-fields
-      patches:
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.deletionPolicy
+  mode: Pipeline
+  pipeline:
+  - functionRef:
+      name: function-patch-and-transform
+    input:
+      apiVersion: pt.fn.crossplane.io/v1beta1
+      kind: Resources
+      patchSets:
+      - name: common-fields
+        patches:
+        - fromFieldPath: spec.resourceConfig.deletionPolicy
           toFieldPath: spec.deletionPolicy
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.region
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.resourceConfig.region
           toFieldPath: spec.forProvider.region
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.providerConfigName
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.resourceConfig.providerConfigName
           toFieldPath: spec.providerConfigRef.name
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.tags
-          toFieldPath: spec.forProvider.tags
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.resourceConfig.tags
           policy:
-            mergeOptions:
-              keepMapValues: true
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.name
+            toFieldPath: MergeObjects
+          toFieldPath: spec.forProvider.tags
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.resourceConfig.name
           toFieldPath: metadata.annotations[crossplane.io/external-name]
-        - fromFieldPath: "metadata.name"
-          toFieldPath: "metadata.name"
+          type: FromCompositeFieldPath
+        - fromFieldPath: metadata.name
+          toFieldPath: metadata.name
           transforms:
-            - type: string
-              string:
-                fmt: "bucket-%s"
-  resources:
-    - name: s3-bucket
-      connectionDetails:
-        - type: FromFieldPath
+          - string:
+              fmt: bucket-%s
+              type: Format
+            type: string
+          type: FromCompositeFieldPath
+      resources:
+      - base:
+          apiVersion: s3.aws.upbound.io/v1beta1
+          kind: Bucket
+          spec:
+            deletionPolicy: Delete
+            forProvider:
+              forceDestroy: true
+              region: us-west-2
+              writeConnectionSecretToRef:
+                namespace: crossplane-system
+        connectionDetails:
+        - fromFieldPath: status.atProvider.id
           name: bucketName
-          fromFieldPath: status.atProvider.id
-      base:
-        apiVersion: s3.aws.upbound.io/v1beta1
-        kind: Bucket
-        spec:
-          deletionPolicy: Delete
-          forProvider:
-            region: us-west-2
-            forceDestroy: true # be careful with this
-            writeConnectionSecretToRef:
-              namespace: crossplane-system
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.atProvider.id
+          type: FromFieldPath
+        name: s3-bucket
+        patches:
+        - patchSetName: common-fields
+          type: PatchSet
+        - fromFieldPath: status.atProvider.id
           toFieldPath: status.bucketName
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.atProvider.id
+          type: ToCompositeFieldPath
+        - fromFieldPath: status.atProvider.id
           toFieldPath: status.bucketArn
           transforms:
-            - type: string
-              string:
-                fmt: "arn:aws:s3:::%s"
-    - name: s3-blockpublicaccess
-      base:
-        apiVersion: s3.aws.upbound.io/v1beta1
-        kind: BucketPublicAccessBlock
-        spec:
-          deletionPolicy: Delete
-          forProvider:
-            bucketSelector:
-              matchControllerRef: true
-            blockPublicAcls: true
-            blockPublicPolicy: true
-            ignorePublicAcls: true
-            restrictPublicBuckets: true
-      patches:
+          - string:
+              fmt: arn:aws:s3:::%s
+              type: Format
+            type: string
+          type: ToCompositeFieldPath
+      - base:
+          apiVersion: s3.aws.upbound.io/v1beta1
+          kind: BucketPublicAccessBlock
+          spec:
+            deletionPolicy: Delete
+            forProvider:
+              blockPublicAcls: true
+              blockPublicPolicy: true
+              bucketSelector:
+                matchControllerRef: true
+              ignorePublicAcls: true
+              restrictPublicBuckets: true
+        name: s3-blockpublicaccess
+        patches:
         - fromFieldPath: spec.resourceConfig.region
           toFieldPath: spec.forProvider.region
+          type: FromCompositeFieldPath
         - fromFieldPath: spec.resourceConfig.providerConfigName
           toFieldPath: spec.providerConfigRef.name
-    - name: s3-serversideencryption
-      base:
-        apiVersion: s3.aws.upbound.io/v1beta1
-        kind: BucketServerSideEncryptionConfiguration
-        spec:
-          deletionPolicy: Delete
-          forProvider:
-            bucketSelector:
-              matchControllerRef: true
-            rule:
+          type: FromCompositeFieldPath
+      - base:
+          apiVersion: s3.aws.upbound.io/v1beta1
+          kind: BucketServerSideEncryptionConfiguration
+          spec:
+            deletionPolicy: Delete
+            forProvider:
+              bucketSelector:
+                matchControllerRef: true
+              rule:
               - applyServerSideEncryptionByDefault:
-                  - sseAlgorithm: AES256
-      patches:
+                - sseAlgorithm: AES256
+        name: s3-serversideencryption
+        patches:
         - fromFieldPath: spec.resourceConfig.providerConfigName
           toFieldPath: spec.providerConfigRef.name
+          type: FromCompositeFieldPath
         - fromFieldPath: spec.resourceConfig.region
           toFieldPath: spec.forProvider.region
-          
+          type: FromCompositeFieldPath
+    step: patch-and-transform
+  writeConnectionSecretsToNamespace: crossplane-system

--- a/compositions/upbound-aws-provider/serverless-microservice/rest-lambda-ddb.yaml
+++ b/compositions/upbound-aws-provider/serverless-microservice/rest-lambda-ddb.yaml
@@ -231,8 +231,7 @@ spec:
               toFieldPath: spec.envVariables[TABLE_NAME]
               policy:
                 fromFieldPath: Required
-                mergeOptions:
-                  keepMapValues: true
+                toFieldPath: MergeObjects
             - type: FromCompositeFieldPath
               fromFieldPath: spec.codeBucketName
               toFieldPath: spec.bucketName
@@ -346,8 +345,7 @@ spec:
               fromFieldPath: spec.resourceConfig.tags
               toFieldPath: spec.resourceConfig.tags
               policy:
-                mergeOptions:
-                  keepMapValues: true
+                toFieldPath: MergeObjects
             - type: FromCompositeFieldPath
               fromFieldPath: metadata.name
               toFieldPath: metadata.name
@@ -391,8 +389,7 @@ spec:
               toFieldPath: spec.envVariables[AUTHORIZER_PASSWORD_ARN]
               policy:
                 fromFieldPath: Required
-                mergeOptions:
-                  keepMapValues: true
+                toFieldPath: MergeObjects
             - type: FromCompositeFieldPath
               fromFieldPath: spec.codeBucketName
               toFieldPath: spec.bucketName

--- a/compositions/upbound-aws-provider/serverless/sns-sqs-lambda-s3.yaml
+++ b/compositions/upbound-aws-provider/serverless/sns-sqs-lambda-s3.yaml
@@ -1,223 +1,222 @@
-
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
-  name: xsnssqslambdas3.awsblueprints.io
   annotations:
     argocd.argoproj.io/sync-wave: "-10"
   labels:
-    awsblueprints.io/provider: aws
     awsblueprints.io/environment: dev
+    awsblueprints.io/provider: aws
     serverless.awsblueprints.io/app: sns-sqs-lambda-s3
+  name: xsnssqslambdas3.awsblueprints.io
 spec:
   compositeTypeRef:
     apiVersion: awsblueprints.io/v1alpha1
     kind: XServerlessApp
-  patchSets:
-    - name: common-fields-composition
-      patches:
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig
+  mode: Pipeline
+  pipeline:
+  - functionRef:
+      name: function-patch-and-transform
+    input:
+      apiVersion: pt.fn.crossplane.io/v1beta1
+      kind: Resources
+      patchSets:
+      - name: common-fields-composition
+        patches:
+        - fromFieldPath: spec.resourceConfig
           toFieldPath: spec.resourceConfig
-    - name: common-lambda
-      patches:
-        - type: FromCompositeFieldPath
-          fromFieldPath: status.bucketName
+          type: FromCompositeFieldPath
+      - name: common-lambda
+        patches:
+        - fromFieldPath: status.bucketName
+          policy:
+            fromFieldPath: Required
+            toFieldPath: MergeObjects
           toFieldPath: spec.envVariables[APP__CONFIG__DESTINATIONBUCKET]
+          type: FromCompositeFieldPath
+        - fromFieldPath: status.bucketName
           policy:
             fromFieldPath: Required
-            mergeOptions:
-              keepMapValues: true
-        - type: FromCompositeFieldPath
-          fromFieldPath: status.bucketName
+            toFieldPath: MergeObjects
           toFieldPath: spec.envVariables[APP__CONFIG__DESTINATIONQUEUE]
-          policy:
-            fromFieldPath: Required
-            mergeOptions:
-              keepMapValues: true
-  resources:
-    - name: sns-sqs
-      base:
-        apiVersion: awsblueprints.io/v1alpha1
-        kind: XFanout
-        spec:
-          compositionSelector:
-            matchLabels:
-              awsblueprints.io/environment: dev
-              awsblueprints.io/provider: aws
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields-composition
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.queueArn
+          type: FromCompositeFieldPath
+      resources:
+      - base:
+          apiVersion: awsblueprints.io/v1alpha1
+          kind: XFanout
+          spec:
+            compositionSelector:
+              matchLabels:
+                awsblueprints.io/environment: dev
+                awsblueprints.io/provider: aws
+        name: sns-sqs
+        patches:
+        - patchSetName: common-fields-composition
+          type: PatchSet
+        - fromFieldPath: status.queueArn
           toFieldPath: status.sourceQueueArn
-        - type: FromCompositeFieldPath
-          fromFieldPath: status.keyName
+          type: ToCompositeFieldPath
+        - fromFieldPath: status.keyName
           toFieldPath: spec.encryptionKey
-    - name: processor-event-source
-      base:
-        apiVersion: awsblueprints.io/v1alpha1
-        kind: EventSourceMapping
-        spec:
-          compositionSelector:
-            matchLabels:
-              esm.awsblueprints.io/service: sqs
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields-composition
-        - type: FromCompositeFieldPath
-          fromFieldPath: status.processorFuncName
+          type: FromCompositeFieldPath
+      - base:
+          apiVersion: awsblueprints.io/v1alpha1
+          kind: EventSourceMapping
+          spec:
+            compositionSelector:
+              matchLabels:
+                esm.awsblueprints.io/service: sqs
+        name: processor-event-source
+        patches:
+        - patchSetName: common-fields-composition
+          type: PatchSet
+        - fromFieldPath: status.processorFuncName
+          policy:
+            fromFieldPath: Required
           toFieldPath: spec.funcName
+          type: FromCompositeFieldPath
+        - fromFieldPath: status.sourceQueueArn
           policy:
             fromFieldPath: Required
-        - type: FromCompositeFieldPath
-          fromFieldPath: status.sourceQueueArn
           toFieldPath: spec.sourceArn
-          policy:
-            fromFieldPath: Required
-    - name: processor-lambda
-      base:
-        apiVersion: awsblueprints.io/v1alpha1
-        kind: XLambdaFunction
-        spec:
-          compositionSelector:
-            matchLabels:
-              awsblueprints.io/provider: aws
-              awsblueprints.io/environment: dev
-              awsblueprints.io/type: zip
-          resourceConfig:
-            providerConfigName: aws-provider-config
-            region: us-west-2
-          handler: main
-          runTime: go1.x
-          envVariables:
-            APP__CONFIG__PROCESSOR: "TRUE"
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields-composition
-        - type: PatchSet
-          patchSetName: common-lambda
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.bucketName
+          type: FromCompositeFieldPath
+      - base:
+          apiVersion: awsblueprints.io/v1alpha1
+          kind: XLambdaFunction
+          spec:
+            compositionSelector:
+              matchLabels:
+                awsblueprints.io/environment: dev
+                awsblueprints.io/provider: aws
+                awsblueprints.io/type: zip
+            envVariables:
+              APP__CONFIG__PROCESSOR: "TRUE"
+            handler: main
+            resourceConfig:
+              providerConfigName: aws-provider-config
+              region: us-west-2
+            runTime: go1.x
+        name: processor-lambda
+        patches:
+        - patchSetName: common-fields-composition
+          type: PatchSet
+        - patchSetName: common-lambda
+          type: PatchSet
+        - fromFieldPath: spec.bucketName
           toFieldPath: spec.bucketName
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.bucketKey
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.bucketKey
           toFieldPath: spec.bucketKey
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.memorySize
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.memorySize
           toFieldPath: spec.memorySize
-        - type: FromCompositeFieldPath
-          fromFieldPath: metadata.name
+          type: FromCompositeFieldPath
+        - fromFieldPath: metadata.name
           toFieldPath: metadata.name
           transforms:
-            - type: string
-              string:
-                fmt: "%s-processor"
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.functionRoleName
+          - string:
+              fmt: '%s-processor'
+              type: Format
+            type: string
+          type: FromCompositeFieldPath
+        - fromFieldPath: status.functionRoleName
           toFieldPath: status.processorRoleName
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.functionName
+          type: ToCompositeFieldPath
+        - fromFieldPath: status.functionName
           toFieldPath: status.processorFuncName
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.functionRoleArn
+          type: ToCompositeFieldPath
+        - fromFieldPath: status.functionRoleArn
           toFieldPath: status.accountNumber
           transforms:
-            - type: string
-              string:
-                type: Regexp
-                regexp:
-                  match: 'arn:aws:iam::(\d+):.*'
-                  group: 1
-    - name: bucket
-      base:
-        apiVersion: awsblueprints.io/v1alpha1
-        kind: XObjectStorage
-        metadata:
-          name: standard-object-storage
-        spec:
-          compositionSelector:
-            matchLabels:
-              awsblueprints.io/provider: aws
-              awsblueprints.io/environment: dev
-              s3.awsblueprints.io/configuration: standard
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields-composition
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.bucketName
+          - string:
+              regexp:
+                group: 1
+                match: arn:aws:iam::(\d+):.*
+              type: Regexp
+            type: string
+          type: ToCompositeFieldPath
+      - base:
+          apiVersion: awsblueprints.io/v1alpha1
+          kind: XObjectStorage
+          metadata:
+            name: standard-object-storage
+          spec:
+            compositionSelector:
+              matchLabels:
+                awsblueprints.io/environment: dev
+                awsblueprints.io/provider: aws
+                s3.awsblueprints.io/configuration: standard
+        name: bucket
+        patches:
+        - patchSetName: common-fields-composition
+          type: PatchSet
+        - fromFieldPath: status.bucketName
           toFieldPath: status.bucketName
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.bucketArn
+          type: ToCompositeFieldPath
+        - fromFieldPath: status.bucketArn
           toFieldPath: status.bucketArn
-    - name: processor-bucket-policy
-      base:
-        apiVersion: awsblueprints.io/v1alpha1
-        kind: IAMPolicy
-        spec:
-          compositionSelector:
-            matchLabels:
-              awsblueprints.io/provider: aws
-              awsblueprints.io/environment: dev
-              iam.awsblueprints.io/policy-type: write
-              iam.awsblueprints.io/service: s3
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields-composition
-        - type: FromCompositeFieldPath
-          fromFieldPath: status.processorRoleName
+          type: ToCompositeFieldPath
+      - base:
+          apiVersion: awsblueprints.io/v1alpha1
+          kind: IAMPolicy
+          spec:
+            compositionSelector:
+              matchLabels:
+                awsblueprints.io/environment: dev
+                awsblueprints.io/provider: aws
+                iam.awsblueprints.io/policy-type: write
+                iam.awsblueprints.io/service: s3
+        name: processor-bucket-policy
+        patches:
+        - patchSetName: common-fields-composition
+          type: PatchSet
+        - fromFieldPath: status.processorRoleName
           toFieldPath: spec.roleName
-        - type: FromCompositeFieldPath
-          fromFieldPath: status.bucketArn
+          type: FromCompositeFieldPath
+        - fromFieldPath: status.bucketArn
           toFieldPath: spec.resourceArn
-    - name: processor-sqs-policy
-      base:
-        apiVersion: awsblueprints.io/v1alpha1
-        kind: IAMPolicy
-        spec:
-          compositionSelector:
-            matchLabels:
-              awsblueprints.io/provider: aws
-              awsblueprints.io/environment: dev
-              iam.awsblueprints.io/policy-type: read
-              iam.awsblueprints.io/service: sqs
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields-composition
-        - type: FromCompositeFieldPath
-          fromFieldPath: status.processorRoleName
+          type: FromCompositeFieldPath
+      - base:
+          apiVersion: awsblueprints.io/v1alpha1
+          kind: IAMPolicy
+          spec:
+            compositionSelector:
+              matchLabels:
+                awsblueprints.io/environment: dev
+                awsblueprints.io/provider: aws
+                iam.awsblueprints.io/policy-type: read
+                iam.awsblueprints.io/service: sqs
+        name: processor-sqs-policy
+        patches:
+        - patchSetName: common-fields-composition
+          type: PatchSet
+        - fromFieldPath: status.processorRoleName
           toFieldPath: spec.roleName
-        - type: FromCompositeFieldPath
-          fromFieldPath: status.sourceQueueArn
+          type: FromCompositeFieldPath
+        - fromFieldPath: status.sourceQueueArn
           toFieldPath: spec.resourceArn
-    - name: kms-key
-      base:
-        apiVersion: awsblueprints.io/v1alpha1
-        kind: XEncryptionKey
-        spec:
-          compositionSelector:
-            matchLabels:
-              awsblueprints.io/provider: aws
-              awsblueprints.io/environment: dev
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields-composition
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.keyArn
+          type: FromCompositeFieldPath
+      - base:
+          apiVersion: awsblueprints.io/v1alpha1
+          kind: XEncryptionKey
+          spec:
+            compositionSelector:
+              matchLabels:
+                awsblueprints.io/environment: dev
+                awsblueprints.io/provider: aws
+        name: kms-key
+        patches:
+        - patchSetName: common-fields-composition
+          type: PatchSet
+        - fromFieldPath: status.keyArn
           toFieldPath: status.kmsKeyArn
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.keyName
+          type: ToCompositeFieldPath
+        - fromFieldPath: status.keyName
           toFieldPath: status.keyName
-        - type: CombineFromComposite
-          toFieldPath: spec.policy
-          policy:
-            fromFieldPath: Required
-          combine:
-            variables:
-              - fromFieldPath: status.accountNumber
+          type: ToCompositeFieldPath
+        - combine:
             strategy: string
             string:
               fmt: |
@@ -243,23 +242,30 @@ spec:
                     }
                   ]
                 }
-    - name: processor-kms-policy
-      base:
-        apiVersion: awsblueprints.io/v1alpha1
-        kind: IAMPolicy
-        spec:
-          compositionSelector:
-            matchLabels:
-              awsblueprints.io/provider: aws
-              awsblueprints.io/environment: dev
-              iam.awsblueprints.io/policy-type: read
-              iam.awsblueprints.io/service: kms
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields-composition
-        - type: FromCompositeFieldPath
-          fromFieldPath: status.processorRoleName
+            variables:
+            - fromFieldPath: status.accountNumber
+          policy:
+            fromFieldPath: Required
+          toFieldPath: spec.policy
+          type: CombineFromComposite
+      - base:
+          apiVersion: awsblueprints.io/v1alpha1
+          kind: IAMPolicy
+          spec:
+            compositionSelector:
+              matchLabels:
+                awsblueprints.io/environment: dev
+                awsblueprints.io/provider: aws
+                iam.awsblueprints.io/policy-type: read
+                iam.awsblueprints.io/service: kms
+        name: processor-kms-policy
+        patches:
+        - patchSetName: common-fields-composition
+          type: PatchSet
+        - fromFieldPath: status.processorRoleName
           toFieldPath: spec.roleName
-        - type: FromCompositeFieldPath
-          fromFieldPath: status.kmsKeyArn
+          type: FromCompositeFieldPath
+        - fromFieldPath: status.kmsKeyArn
           toFieldPath: spec.resourceArn
+          type: FromCompositeFieldPath
+    step: patch-and-transform

--- a/compositions/upbound-aws-provider/serverless/sqs-lambda-s3.yaml
+++ b/compositions/upbound-aws-provider/serverless/sqs-lambda-s3.yaml
@@ -1,193 +1,199 @@
-
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
-  name: xsqslambdas3.awsblueprints.io
   annotations:
     argocd.argoproj.io/sync-wave: "-10"
   labels:
-    awsblueprints.io/provider: aws
     awsblueprints.io/environment: dev
+    awsblueprints.io/provider: aws
     serverless.awsblueprints.io/app: sqs-lambda-s3
+  name: xsqslambdas3.awsblueprints.io
 spec:
   compositeTypeRef:
     apiVersion: awsblueprints.io/v1alpha1
     kind: XServerlessApp
-  patchSets:
-    - name: common-fields-composition
-      patches:
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig
+  mode: Pipeline
+  pipeline:
+  - functionRef:
+      name: function-patch-and-transform
+    input:
+      apiVersion: pt.fn.crossplane.io/v1beta1
+      kind: Resources
+      patchSets:
+      - name: common-fields-composition
+        patches:
+        - fromFieldPath: spec.resourceConfig
           toFieldPath: spec.resourceConfig
-    - name: common-lambda
-      patches:
-        - type: FromCompositeFieldPath
-          fromFieldPath: status.bucketName
+          type: FromCompositeFieldPath
+      - name: common-lambda
+        patches:
+        - fromFieldPath: status.bucketName
+          policy:
+            fromFieldPath: Required
+            toFieldPath: MergeObjects
           toFieldPath: spec.envVariables[APP__CONFIG__DESTINATIONBUCKET]
+          type: FromCompositeFieldPath
+        - fromFieldPath: status.bucketName
           policy:
             fromFieldPath: Required
-            mergeOptions:
-              keepMapValues: true
-        - type: FromCompositeFieldPath
-          fromFieldPath: status.bucketName
+            toFieldPath: MergeObjects
           toFieldPath: spec.envVariables[APP__CONFIG__DESTINATIONQUEUE]
-          policy:
-            fromFieldPath: Required
-            mergeOptions:
-              keepMapValues: true
-  resources:
-    - name: sqs
-      base:
-        apiVersion: awsblueprints.io/v1alpha1
-        kind: XQueue
-        spec:
-          compositionSelector:
-            matchLabels:
-              awsblueprints.io/provider: aws
-              awsblueprints.io/environment: dev
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields-composition
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.queueArn
+          type: FromCompositeFieldPath
+      resources:
+      - base:
+          apiVersion: awsblueprints.io/v1alpha1
+          kind: XQueue
+          spec:
+            compositionSelector:
+              matchLabels:
+                awsblueprints.io/environment: dev
+                awsblueprints.io/provider: aws
+        name: sqs
+        patches:
+        - patchSetName: common-fields-composition
+          type: PatchSet
+        - fromFieldPath: status.queueArn
           toFieldPath: status.sourceQueueArn
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.queueArn
+          type: ToCompositeFieldPath
+        - fromFieldPath: status.queueArn
           toFieldPath: status.accountNumber
           transforms:
-            - type: string
-              string:
-                type: Regexp
-                regexp:
-                  match: 'arn:aws:sqs:.*:(\d+):.*'
-                  group: 1
-    - name: processor-event-source
-      base:
-        apiVersion: awsblueprints.io/v1alpha1
-        kind: EventSourceMapping
-        spec:
-          compositionSelector:
-            matchLabels:
-              esm.awsblueprints.io/service: sqs
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields-composition
-        - type: FromCompositeFieldPath
-          fromFieldPath: status.processorFuncName
+          - string:
+              regexp:
+                group: 1
+                match: arn:aws:sqs:.*:(\d+):.*
+              type: Regexp
+            type: string
+          type: ToCompositeFieldPath
+      - base:
+          apiVersion: awsblueprints.io/v1alpha1
+          kind: EventSourceMapping
+          spec:
+            compositionSelector:
+              matchLabels:
+                esm.awsblueprints.io/service: sqs
+        name: processor-event-source
+        patches:
+        - patchSetName: common-fields-composition
+          type: PatchSet
+        - fromFieldPath: status.processorFuncName
+          policy:
+            fromFieldPath: Required
           toFieldPath: spec.funcName
+          type: FromCompositeFieldPath
+        - fromFieldPath: status.sourceQueueArn
           policy:
             fromFieldPath: Required
-        - type: FromCompositeFieldPath
-          fromFieldPath: status.sourceQueueArn
           toFieldPath: spec.sourceArn
-          policy:
-            fromFieldPath: Required
-    - name: processor-lambda
-      base:
-        apiVersion: awsblueprints.io/v1alpha1
-        kind: XLambdaFunction
-        spec:
-          compositionSelector:
-            matchLabels:
-              awsblueprints.io/provider: aws
-              awsblueprints.io/environment: dev
-              awsblueprints.io/type: container
-          envVariables:
-            APP__CONFIG__PROCESSOR: "TRUE"
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields-composition
-        - type: PatchSet
-          patchSetName: common-lambda
-        - type: CombineFromComposite
-          policy:
-            fromFieldPath: Required
-          combine:
-            variables:
-              - fromFieldPath: status.accountNumber
-              - fromFieldPath: spec.resourceConfig.region
-              - fromFieldPath: spec.imageName
+          type: FromCompositeFieldPath
+      - base:
+          apiVersion: awsblueprints.io/v1alpha1
+          kind: XLambdaFunction
+          spec:
+            compositionSelector:
+              matchLabels:
+                awsblueprints.io/environment: dev
+                awsblueprints.io/provider: aws
+                awsblueprints.io/type: container
+            envVariables:
+              APP__CONFIG__PROCESSOR: "TRUE"
+        name: processor-lambda
+        patches:
+        - patchSetName: common-fields-composition
+          type: PatchSet
+        - patchSetName: common-lambda
+          type: PatchSet
+        - combine:
             strategy: string
             string:
-              fmt: "%s.dkr.ecr.%s.amazonaws.com/%s"
+              fmt: '%s.dkr.ecr.%s.amazonaws.com/%s'
+            variables:
+            - fromFieldPath: status.accountNumber
+            - fromFieldPath: spec.resourceConfig.region
+            - fromFieldPath: spec.imageName
+          policy:
+            fromFieldPath: Required
           toFieldPath: spec.imageUri
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.memorySize
+          type: CombineFromComposite
+        - fromFieldPath: spec.memorySize
           toFieldPath: spec.memorySize
-        - type: FromCompositeFieldPath
-          fromFieldPath: metadata.name
+          type: FromCompositeFieldPath
+        - fromFieldPath: metadata.name
           toFieldPath: metadata.name
           transforms:
-            - type: string
-              string:
-                fmt: "%s-processor"
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.functionRoleName
+          - string:
+              fmt: '%s-processor'
+              type: Format
+            type: string
+          type: FromCompositeFieldPath
+        - fromFieldPath: status.functionRoleName
           toFieldPath: status.processorRoleName
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.functionName
+          type: ToCompositeFieldPath
+        - fromFieldPath: status.functionName
           toFieldPath: status.processorFuncName
-    - name: bucket
-      base:
-        apiVersion: awsblueprints.io/v1alpha1
-        kind: XObjectStorage
-        metadata:
-          name: standard-object-storage
-        spec:
-          compositionSelector:
-            matchLabels:
-              awsblueprints.io/provider: aws
-              awsblueprints.io/environment: dev
-              s3.awsblueprints.io/configuration: standard
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields-composition
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.bucketName
+          type: ToCompositeFieldPath
+      - base:
+          apiVersion: awsblueprints.io/v1alpha1
+          kind: XObjectStorage
+          metadata:
+            name: standard-object-storage
+          spec:
+            compositionSelector:
+              matchLabels:
+                awsblueprints.io/environment: dev
+                awsblueprints.io/provider: aws
+                s3.awsblueprints.io/configuration: standard
+        name: bucket
+        patches:
+        - patchSetName: common-fields-composition
+          type: PatchSet
+        - fromFieldPath: status.bucketName
           toFieldPath: status.bucketName
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.bucketArn
+          type: ToCompositeFieldPath
+        - fromFieldPath: status.bucketArn
           toFieldPath: status.bucketArn
-    - name: processor-bucket-policy
-      base:
-        apiVersion: awsblueprints.io/v1alpha1
-        kind: IAMPolicy
-        spec:
-          compositionSelector:
-            matchLabels:
-              awsblueprints.io/provider: aws
-              awsblueprints.io/environment: dev
-              iam.awsblueprints.io/policy-type: write
-              iam.awsblueprints.io/service: s3
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields-composition
-        - type: FromCompositeFieldPath
-          fromFieldPath: status.processorRoleName
+          type: ToCompositeFieldPath
+      - base:
+          apiVersion: awsblueprints.io/v1alpha1
+          kind: IAMPolicy
+          spec:
+            compositionSelector:
+              matchLabels:
+                awsblueprints.io/environment: dev
+                awsblueprints.io/provider: aws
+                iam.awsblueprints.io/policy-type: write
+                iam.awsblueprints.io/service: s3
+        name: processor-bucket-policy
+        patches:
+        - patchSetName: common-fields-composition
+          type: PatchSet
+        - fromFieldPath: status.processorRoleName
           toFieldPath: spec.roleName
-        - type: FromCompositeFieldPath
-          fromFieldPath: status.bucketArn
+          type: FromCompositeFieldPath
+        - fromFieldPath: status.bucketArn
           toFieldPath: spec.resourceArn
-    - name: processor-sqs-policy
-      base:
-        apiVersion: awsblueprints.io/v1alpha1
-        kind: IAMPolicy
-        spec:
-          compositionSelector:
-            matchLabels:
-              awsblueprints.io/provider: aws
-              awsblueprints.io/environment: dev
-              iam.awsblueprints.io/policy-type: read
-              iam.awsblueprints.io/service: sqs
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields-composition
-        - type: FromCompositeFieldPath
-          fromFieldPath: status.processorRoleName
+          type: FromCompositeFieldPath
+      - base:
+          apiVersion: awsblueprints.io/v1alpha1
+          kind: IAMPolicy
+          spec:
+            compositionSelector:
+              matchLabels:
+                awsblueprints.io/environment: dev
+                awsblueprints.io/provider: aws
+                iam.awsblueprints.io/policy-type: read
+                iam.awsblueprints.io/service: sqs
+        name: processor-sqs-policy
+        patches:
+        - patchSetName: common-fields-composition
+          type: PatchSet
+        - fromFieldPath: status.processorRoleName
           toFieldPath: spec.roleName
-        - type: FromCompositeFieldPath
-          fromFieldPath: status.sourceQueueArn
+          type: FromCompositeFieldPath
+        - fromFieldPath: status.sourceQueueArn
           toFieldPath: spec.resourceArn
+          type: FromCompositeFieldPath
+    step: patch-and-transform

--- a/compositions/upbound-aws-provider/sns-sqs/sns-sqs.yaml
+++ b/compositions/upbound-aws-provider/sns-sqs/sns-sqs.yaml
@@ -4,146 +4,148 @@
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
-  name: xfanout.awsblueprints.io
   labels:
     awsblueprints.io/environment: dev
     awsblueprints.io/provider: aws
+  name: xfanout.awsblueprints.io
 spec:
   compositeTypeRef:
     apiVersion: awsblueprints.io/v1alpha1
     kind: XFanout
-  patchSets:
-    - name: common-fields-composition
-      patches:
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig
+  mode: Pipeline
+  pipeline:
+  - functionRef:
+      name: function-patch-and-transform
+    input:
+      apiVersion: pt.fn.crossplane.io/v1beta1
+      kind: Resources
+      patchSets:
+      - name: common-fields-composition
+        patches:
+        - fromFieldPath: spec.resourceConfig
           toFieldPath: spec.resourceConfig
-        - fromFieldPath: "metadata.name"
-          toFieldPath: "metadata.name"
+          type: FromCompositeFieldPath
+        - fromFieldPath: metadata.name
+          toFieldPath: metadata.name
           transforms:
-            - type: string
-              string:
-                fmt: "sns-sqs-%s"
-    - name: common-fields
-      patches:
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.deletionPolicy
+          - string:
+              fmt: sns-sqs-%s
+              type: Format
+            type: string
+          type: FromCompositeFieldPath
+      - name: common-fields
+        patches:
+        - fromFieldPath: spec.resourceConfig.deletionPolicy
           toFieldPath: spec.deletionPolicy
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.region
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.resourceConfig.region
           toFieldPath: spec.forProvider.region
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.providerConfigName
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.resourceConfig.providerConfigName
           toFieldPath: spec.providerConfigRef.name
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.name
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.resourceConfig.name
           toFieldPath: metadata.annotations[crossplane.io/external-name]
-        - fromFieldPath: "metadata.name"
-          toFieldPath: "metadata.name"
+          type: FromCompositeFieldPath
+        - fromFieldPath: metadata.name
+          toFieldPath: metadata.name
           transforms:
-            - type: string
-              string:
-                fmt: "sns-sqs-%s"
-  resources:
-    - name: sqs
-      base:
-        apiVersion: awsblueprints.io/v1alpha1
-        kind: XQueue
-        spec:
-          compositionSelector:
-            matchLabels:
-              awsblueprints.io/provider: aws
-              awsblueprints.io/environment: dev
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields-composition
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.encryptionKey
-          toFieldPath: spec.encryptionKey
+          - string:
+              fmt: sns-sqs-%s
+              type: Format
+            type: string
+          type: FromCompositeFieldPath
+      resources:
+      - base:
+          apiVersion: awsblueprints.io/v1alpha1
+          kind: XQueue
+          spec:
+            compositionSelector:
+              matchLabels:
+                awsblueprints.io/environment: dev
+                awsblueprints.io/provider: aws
+        name: sqs
+        patches:
+        - patchSetName: common-fields-composition
+          type: PatchSet
+        - fromFieldPath: spec.encryptionKey
           policy:
             fromFieldPath: Required
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.queueArn
+          toFieldPath: spec.encryptionKey
+          type: FromCompositeFieldPath
+        - fromFieldPath: status.queueArn
           toFieldPath: status.queueArn
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.queueUrl
+          type: ToCompositeFieldPath
+        - fromFieldPath: status.queueUrl
           toFieldPath: status.queueUrl
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.tags
-          toFieldPath: spec.resourceConfig.tags
+          type: ToCompositeFieldPath
+        - fromFieldPath: spec.resourceConfig.tags
           policy:
-            mergeOptions:
-              keepMapValues: true
-    - name: sns
-      base:
-        apiVersion: awsblueprints.io/v1alpha1
-        kind: XNotification
-        spec:
-          compositionSelector:
-            matchLabels:
-              awsblueprints.io/provider: aws
-              awsblueprints.io/environment: dev
-              notification.awsblueprints.io/type: standard
-              notification.awsblueprints.io/sns-config: cloudwatch
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields-composition
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.encryptionKey
+            toFieldPath: MergeObjects
+          toFieldPath: spec.resourceConfig.tags
+          type: FromCompositeFieldPath
+      - base:
+          apiVersion: awsblueprints.io/v1alpha1
+          kind: XNotification
+          spec:
+            compositionSelector:
+              matchLabels:
+                awsblueprints.io/environment: dev
+                awsblueprints.io/provider: aws
+                notification.awsblueprints.io/sns-config: cloudwatch
+                notification.awsblueprints.io/type: standard
+        name: sns
+        patches:
+        - patchSetName: common-fields-composition
+          type: PatchSet
+        - fromFieldPath: spec.encryptionKey
+          policy:
+            fromFieldPath: Required
           toFieldPath: spec.encryptionKey
-          policy:
-            fromFieldPath: Required
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.topicArn
+          type: FromCompositeFieldPath
+        - fromFieldPath: status.topicArn
           toFieldPath: status.topicArn
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.tags
+          type: ToCompositeFieldPath
+        - fromFieldPath: spec.resourceConfig.tags
+          policy:
+            toFieldPath: MergeObjects
           toFieldPath: spec.resourceConfig.tags
+          type: FromCompositeFieldPath
+      - base:
+          apiVersion: sns.aws.upbound.io/v1beta1
+          kind: TopicSubscription
+          spec:
+            forProvider:
+              protocol: sqs
+        name: subscription
+        patches:
+        - patchSetName: common-fields
+          type: PatchSet
+        - fromFieldPath: status.queueArn
           policy:
-            mergeOptions:
-              keepMapValues: true
-    - name: subscription
-      base:
-        apiVersion: sns.aws.upbound.io/v1beta1
-        kind: TopicSubscription
-        spec:
-          forProvider:
-            protocol: sqs
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields
-        - type: FromCompositeFieldPath
-          fromFieldPath: status.queueArn
+            fromFieldPath: Required
           toFieldPath: spec.forProvider.endpoint
+          type: FromCompositeFieldPath
+        - fromFieldPath: status.topicArn
           policy:
             fromFieldPath: Required
-        - type: FromCompositeFieldPath
-          fromFieldPath: status.topicArn
           toFieldPath: spec.forProvider.topicArn
+          type: FromCompositeFieldPath
+      - base:
+          apiVersion: sqs.aws.upbound.io/v1beta1
+          kind: QueuePolicy
+          spec:
+            forProvider: {}
+        name: sns-queue-policy
+        patches:
+        - patchSetName: common-fields
+          type: PatchSet
+        - fromFieldPath: status.queueUrl
           policy:
             fromFieldPath: Required
-    - name: sns-queue-policy
-      base:
-        apiVersion: sqs.aws.upbound.io/v1beta1
-        kind: QueuePolicy
-        spec:
-          forProvider: {}
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields
-        - type: FromCompositeFieldPath
-          fromFieldPath: status.queueUrl
           toFieldPath: spec.forProvider.queueUrl
-          policy:
-            fromFieldPath: Required
-        - type: CombineFromComposite
-          toFieldPath: spec.forProvider.policy
-          policy:
-            fromFieldPath: Required
-          combine:
-            variables:
-              - fromFieldPath: status.queueArn
-              - fromFieldPath: status.topicArn
+          type: FromCompositeFieldPath
+        - combine:
             strategy: string
             string:
               fmt: |
@@ -165,3 +167,11 @@ spec:
                     }
                   ]
                 }
+            variables:
+            - fromFieldPath: status.queueArn
+            - fromFieldPath: status.topicArn
+          policy:
+            fromFieldPath: Required
+          toFieldPath: spec.forProvider.policy
+          type: CombineFromComposite
+    step: patch-and-transform

--- a/compositions/upbound-aws-provider/sns/sns.yaml
+++ b/compositions/upbound-aws-provider/sns/sns.yaml
@@ -4,125 +4,136 @@
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
-  name: sns.notification.upbound.awsblueprints.io
   labels:
-    awsblueprints.io/provider: aws
     awsblueprints.io/environment: dev
-    notification.awsblueprints.io/type: standard
+    awsblueprints.io/provider: aws
     notification.awsblueprints.io/sns-config: cloudwatch
+    notification.awsblueprints.io/type: standard
+  name: sns.notification.upbound.awsblueprints.io
 spec:
   compositeTypeRef:
     apiVersion: awsblueprints.io/v1alpha1
     kind: XNotification
-  patchSets:
-    - name: common-fields
-      patches:
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.deletionPolicy
+  mode: Pipeline
+  pipeline:
+  - functionRef:
+      name: function-patch-and-transform
+    input:
+      apiVersion: pt.fn.crossplane.io/v1beta1
+      kind: Resources
+      patchSets:
+      - name: common-fields
+        patches:
+        - fromFieldPath: spec.resourceConfig.deletionPolicy
           toFieldPath: spec.deletionPolicy
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.providerConfigName
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.resourceConfig.providerConfigName
           toFieldPath: spec.providerConfigRef.name
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.name
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.resourceConfig.name
           toFieldPath: metadata.annotations[crossplane.io/external-name]
-        - fromFieldPath: "metadata.name"
-          toFieldPath: "metadata.name"
+          type: FromCompositeFieldPath
+        - fromFieldPath: metadata.name
+          toFieldPath: metadata.name
           transforms:
-            - type: string
-              string:
-                fmt: "topic-%s"
-  resources:
-    - name: sns-feedback
-      base:
-        apiVersion: iam.aws.upbound.io/v1beta1
-        kind: Role
-        metadata:
-          labels:
-            testing.awsblueprints.io/name: sns-feedback
-        spec:
-          deletionPolicy: Delete
-          forProvider:
-            assumeRolePolicy: |
-              {
-                "Version": "2012-10-17",
-                "Statement": [
-                  {
-                    "Effect": "Allow",
-                    "Principal": {
-                      "Service": "sns.amazonaws.com"
-                    },
-                    "Action": "sts:AssumeRole"
-                  }
-                ]
-              }
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields
-        - fromFieldPath: "metadata.name"
-          toFieldPath: "metadata.name"
+          - string:
+              fmt: topic-%s
+              type: Format
+            type: string
+          type: FromCompositeFieldPath
+      resources:
+      - base:
+          apiVersion: iam.aws.upbound.io/v1beta1
+          kind: Role
+          metadata:
+            labels:
+              testing.awsblueprints.io/name: sns-feedback
+          spec:
+            deletionPolicy: Delete
+            forProvider:
+              assumeRolePolicy: |
+                {
+                  "Version": "2012-10-17",
+                  "Statement": [
+                    {
+                      "Effect": "Allow",
+                      "Principal": {
+                        "Service": "sns.amazonaws.com"
+                      },
+                      "Action": "sts:AssumeRole"
+                    }
+                  ]
+                }
+        name: sns-feedback
+        patches:
+        - patchSetName: common-fields
+          type: PatchSet
+        - fromFieldPath: metadata.name
+          toFieldPath: metadata.name
           transforms:
-            - type: string
-              string:
-                fmt: "sns-feedback-%s"
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.tags
-          toFieldPath: spec.forProvider.tags
+          - string:
+              fmt: sns-feedback-%s
+              type: Format
+            type: string
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.resourceConfig.tags
           policy:
-            mergeOptions:
-              keepMapValues: true
-    - name: sns-feedback-policy-attachment
-      base:
-        apiVersion: iam.aws.upbound.io/v1beta1
-        kind: RolePolicyAttachment
-        spec:
-          deletionPolicy: Delete
-          forProvider:
-            policyArn: arn:aws:iam::aws:policy/service-role/AmazonSNSRole
-            roleSelector:
-              matchControllerRef: true
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields
-    - name: sns
-      base:
-        apiVersion: sns.aws.upbound.io/v1beta1
-        kind: Topic
-        spec:
-          deletionPolicy: Delete
-          forProvider:
-            sqsSuccessFeedbackSampleRate: 100
-            sqsFailureFeedbackRoleArnSelector:
-              matchLabels:
-                testing.awsblueprints.io/name: sns-feedback
-            sqsSuccessFeedbackRoleArnSelector:
-              matchLabels:
-                testing.awsblueprints.io/name: sns-feedback
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.encryptionKey
+            toFieldPath: MergeObjects
+          toFieldPath: spec.forProvider.tags
+          type: FromCompositeFieldPath
+      - base:
+          apiVersion: iam.aws.upbound.io/v1beta1
+          kind: RolePolicyAttachment
+          spec:
+            deletionPolicy: Delete
+            forProvider:
+              policyArn: arn:aws:iam::aws:policy/service-role/AmazonSNSRole
+              roleSelector:
+                matchControllerRef: true
+        name: sns-feedback-policy-attachment
+        patches:
+        - patchSetName: common-fields
+          type: PatchSet
+      - base:
+          apiVersion: sns.aws.upbound.io/v1beta1
+          kind: Topic
+          spec:
+            deletionPolicy: Delete
+            forProvider:
+              sqsFailureFeedbackRoleArnSelector:
+                matchLabels:
+                  testing.awsblueprints.io/name: sns-feedback
+              sqsSuccessFeedbackRoleArnSelector:
+                matchLabels:
+                  testing.awsblueprints.io/name: sns-feedback
+              sqsSuccessFeedbackSampleRate: 100
+        name: sns
+        patches:
+        - patchSetName: common-fields
+          type: PatchSet
+        - fromFieldPath: spec.encryptionKey
           toFieldPath: spec.forProvider.kmsMasterKeyId
-        - type: FromCompositeFieldPath
-          fromFieldPath: metadata.name
+          type: FromCompositeFieldPath
+        - fromFieldPath: metadata.name
           toFieldPath: spec.forProvider.displayName
           transforms:
-            - type: string
-              string:
-                fmt: "managed by crossplane object %s"
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.atProvider.arn
+          - string:
+              fmt: managed by crossplane object %s
+              type: Format
+            type: string
+          type: FromCompositeFieldPath
+        - fromFieldPath: status.atProvider.arn
           toFieldPath: status.topicArn
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.atProvider.id
+          type: ToCompositeFieldPath
+        - fromFieldPath: status.atProvider.id
           toFieldPath: status.topicId
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.region
+          type: ToCompositeFieldPath
+        - fromFieldPath: spec.resourceConfig.region
           toFieldPath: spec.forProvider.region
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.tags
-          toFieldPath: spec.forProvider.tags
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.resourceConfig.tags
           policy:
-            mergeOptions:
-              keepMapValues: true
+            toFieldPath: MergeObjects
+          toFieldPath: spec.forProvider.tags
+          type: FromCompositeFieldPath
+    step: patch-and-transform

--- a/compositions/upbound-aws-provider/sqs/sqs.yaml
+++ b/compositions/upbound-aws-provider/sqs/sqs.yaml
@@ -4,57 +4,64 @@
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
-  name: sqs.queue.aws.upbound.awsblueprints.io
   labels:
-    awsblueprints.io/provider: aws
     awsblueprints.io/environment: dev
+    awsblueprints.io/provider: aws
+  name: sqs.queue.aws.upbound.awsblueprints.io
 spec:
   compositeTypeRef:
     apiVersion: awsblueprints.io/v1alpha1
     kind: XQueue
-  patchSets:
-    - name: common-fields
-      patches:
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.deletionPolicy
+  mode: Pipeline
+  pipeline:
+  - functionRef:
+      name: function-patch-and-transform
+    input:
+      apiVersion: pt.fn.crossplane.io/v1beta1
+      kind: Resources
+      patchSets:
+      - name: common-fields
+        patches:
+        - fromFieldPath: spec.resourceConfig.deletionPolicy
           toFieldPath: spec.deletionPolicy
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.region
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.resourceConfig.region
           toFieldPath: spec.forProvider.region
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.providerConfigName
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.resourceConfig.providerConfigName
           toFieldPath: spec.providerConfigRef.name
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.tags
-          toFieldPath: spec.forProvider.tags
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.resourceConfig.tags
           policy:
-            mergeOptions:
-              keepMapValues: true
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.resourceConfig.name
+            toFieldPath: MergeObjects
+          toFieldPath: spec.forProvider.tags
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.resourceConfig.name
           toFieldPath: metadata.annotations[crossplane.io/external-name]
-  resources:
-    - name: sqs
-      base:
-        apiVersion: sqs.aws.upbound.io/v1beta1
-        kind: Queue
-        spec:
-          deletionPolicy: Delete
-          forProvider:
-            delaySeconds: 10
-            messageRetentionSeconds: 345600
-      patches:
-        - type: PatchSet
-          patchSetName: common-fields
-        - type: FromCompositeFieldPath
-          fromFieldPath: metadata.name
+          type: FromCompositeFieldPath
+      resources:
+      - base:
+          apiVersion: sqs.aws.upbound.io/v1beta1
+          kind: Queue
+          spec:
+            deletionPolicy: Delete
+            forProvider:
+              delaySeconds: 10
+              messageRetentionSeconds: 345600
+        name: sqs
+        patches:
+        - patchSetName: common-fields
+          type: PatchSet
+        - fromFieldPath: metadata.name
           toFieldPath: spec.forProvider.name
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.encryptionKey
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.encryptionKey
           toFieldPath: spec.forProvider.kmsMasterKeyId
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.atProvider.arn
+          type: FromCompositeFieldPath
+        - fromFieldPath: status.atProvider.arn
           toFieldPath: status.queueArn
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.atProvider.url
+          type: ToCompositeFieldPath
+        - fromFieldPath: status.atProvider.url
           toFieldPath: status.queueUrl
+          type: ToCompositeFieldPath
+    step: patch-and-transform


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
Refactors `Composition` resources to use `Pipeline` mode to handle removal of native `EnvironmentConfigs` support which has moved to functions. Details [available here](https://docs.crossplane.io/v1.19/concepts/environment-configs/). Fixes #215 

### Motivation

To remain compatible with Crossplane v1.18 and newer

### More

- [x] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)

- [x] Yes, I have added a new example under [examples](https://github.com/aws-samples/crossplane-aws-blueprints/tree/main/examples) to support my PR

- [x] Yes, I have updated the [docs](https://github.com/aws-samples/crossplane-aws-blueprints/tree/main/doc) for this feature

- [x] Yes, I have linked to an issue or feature request (applicable to PRs that solves a bug or a feature request)

**Note**:
 - Not all the PRs require examples and docs
 - We prefer small, well tested pull requests. Please ensure your pull requests are self-contained, and commits are squashed

### For Moderators
- [x] E2E Test successfully complete before merge?

### Additional Notes

The PR has refactors for the `upbound-aws-provider` compositions. We aim to convert all Compositions but would appreciate early feedback. This should be considered a breaking change as any (kustomize) patches which are applied to Composition resources will have to be updated accordingly.
