### PR TITLE
fix: upgrade mkdocs-material to >=9.5.32

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install mkdocs-material==9.5.21 \
+          python -m pip install mkdocs-material==9.5.32 \
             mkdocs-include-markdown-plugin==6.0.6 \
             mkdocs-awesome-pages-plugin==2.9.2 \
             mkdocs-glightbox==0.1.0 \


### PR DESCRIPTION
Upgrades mkdocs-material dependency to >=9.5.32 which includes security improvements.

No functional changes to documentation content or search functionality.